### PR TITLE
fix: Allow VisualizerDifferences to work with OEIS sequences

### DIFF
--- a/src/visualizers/VisualizerDifferences.ts
+++ b/src/visualizers/VisualizerDifferences.ts
@@ -58,16 +58,11 @@ class VizDifferences extends VisualizerDefault implements VisualizerInterface {
 
 		const workingSequence = [];
 
-		const start = Number(this.settings.n) - Number(levels);
-		const end = Number(this.settings.n);
-		const count = ((start + end) * (end - start + 1)) / 2;
-
-		for (let i = 0; i < count; i++) {
+		for (let i = 0; i < n; i++) {
 			workingSequence.push(sequence.getElement(i)); //workingSequence cannibalizes first n elements of sequence.
 		}
 
-
-		for (let i = 0; i < this.settings.levels; i++) {
+		for (let i = 0; i < levels; i++) {
 			console.log(workingSequence);
 			hue = (i * 255 / 6) % 255;
 			myColor = this.sketch.color(hue, 150, 200);
@@ -79,7 +74,7 @@ class VizDifferences extends VisualizerDefault implements VisualizerInterface {
 				}
 			}
 
-			workingSequence.length = workingSequence.length - 1; //Removes last element.
+			workingSequence.pop();
 			firstX = firstX + (1 / 2) * xDelta; //Moves line forward half for pyramid shape.
 
 		}


### PR DESCRIPTION
  The problem was that VisualizerDifferences was requesting far too many
  terms from the sequence, and so ran into trouble when there weren't more
  terms available (say if you hadn't loaded that many from the OEIS) and the
  unhandled errors terminated the operation of the visualizer.

  There is an underlying issue, however, that there is not a graceful
  convention for handling unavailable values in a sequence; that deserves
  a separate issue.

  Resolves #17.