### PR TITLE
refactor: Delineate three kinds of Sequence items

### DIFF
--- a/src/components/SeqGetter.vue
+++ b/src/components/SeqGetter.vue
@@ -1,6 +1,6 @@
 <template>
     <a v-on:click="$emit('load-seq')">
-        <li class="list-group-item">Get Sequence</li>
+        <li class="list-group-item">{{ title }}</li>
     </a>
 </template>
 
@@ -8,7 +8,8 @@
 export default {
     name: 'SeqGetter',
     props: {
-        oeisId: String
+        title: String,
+        instanceId: String
     }
 }
 </script>

--- a/src/components/SeqSelector.vue
+++ b/src/components/SeqSelector.vue
@@ -1,12 +1,12 @@
 <template>
-    <div v-if="!isOeis">
+    <div v-if="!isInstance">
         <a v-on:click="$emit('set-seq-params')">
             <li class="list-group-item">{{ title }}</li>
         </a>
     </div>
     <div v-else>
-        <a v-on:click="$emit('stage-oeis-seq')">
-            <li class="list-group-item">OEIS: {{ title }}</li>
+        <a v-on:click="$emit('stage-instance')">
+            <li class="list-group-item">Custom: {{ title }}</li>
         </a>
     </div>
 </template>
@@ -16,7 +16,7 @@ export default {
     name: 'SeqSelector',
     props: {
         title: String,
-        isOeis: Boolean
+        isInstance: Boolean
     }
 }
 </script>

--- a/src/components/SeqVizParamsModal.vue
+++ b/src/components/SeqVizParamsModal.vue
@@ -33,8 +33,8 @@
             </form>
         </div>
         <div class="modal-footer">
-            <button v-if="!loadingOeis" v-on:click="$emit('submitParams')" type="button" class="btn btn-primary">Save changes</button>
-            <button v-if="loadingOeis" v-on:click="$emit('submitOeisParams')" type="button" class="btn btn-primary">Load OEIS data</button>
+            <button v-if="!loadingInstance" v-on:click="$emit('submitParams')" type="button" class="btn btn-primary">Save changes</button>
+            <button v-if="loadingInstance" v-on:click="$emit('submitInstance')" type="button" class="btn btn-primary">Add this sequence</button>
             <button v-on:click="$emit('closeModal')" type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
         </div>
         </div>
@@ -53,7 +53,7 @@ export default Vue.extend({
     props: {
         params: Array,
         errors: Array,
-        loadingOeis: Boolean
+        loadingInstance: Boolean
     },
     computed: {
         ParamType: () => ParamType

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -1,5 +1,6 @@
 import { ValidationStatus } from '@/shared/ValidationStatus';
-import { SequenceParamsSchema } from './SequenceInterface';
+import { SequenceParamsSchema, SequenceExportModule,
+         SequenceExportKind } from './SequenceInterface';
 import { SequenceCached } from './SequenceCached';
 
 import axios from 'axios'
@@ -60,3 +61,9 @@ export default class OEISSequenceTemplate extends SequenceCached {
     }
 
 }
+
+export const exportModule = new SequenceExportModule(
+    OEISSequenceTemplate,
+    "Add OEIS Sequence",
+    SequenceExportKind.GETTER
+);

--- a/src/sequences/SequenceConstant.ts
+++ b/src/sequences/SequenceConstant.ts
@@ -1,5 +1,6 @@
 import { ValidationStatus } from '@/shared/ValidationStatus';
-import { SequenceParamsSchema, SequenceExportModule } from './SequenceInterface';
+import { SequenceParamsSchema, SequenceExportModule,
+         SequenceExportKind } from './SequenceInterface';
 import { SequenceClassDefault } from './SequenceClassDefault';
 
 /**
@@ -50,5 +51,6 @@ class SequenceConstant extends SequenceClassDefault {
 
 export const exportModule = new SequenceExportModule(
     SequenceConstant,
-    "Constant Sequence"
+    "Constant Sequence",
+    SequenceExportKind.FAMILY
 );

--- a/src/sequences/SequenceFormula.ts
+++ b/src/sequences/SequenceFormula.ts
@@ -1,5 +1,6 @@
 import { ValidationStatus } from '@/shared/ValidationStatus';
-import { SequenceParamsSchema, SequenceExportModule } from './SequenceInterface';
+import { SequenceParamsSchema, SequenceExportModule,
+         SequenceExportKind } from './SequenceInterface';
 import { SequenceCached } from './SequenceCached';
 import * as math from 'mathjs';
 
@@ -74,5 +75,6 @@ class SequenceFormula extends SequenceCached {
 
 export const exportModule = new SequenceExportModule(
     SequenceFormula,
-    "Sequence by Formula"
+    "Sequence by Formula",
+    SequenceExportKind.FAMILY
 );

--- a/src/sequences/SequenceInterface.ts
+++ b/src/sequences/SequenceInterface.ts
@@ -61,22 +61,42 @@ export interface SequenceConstructor {
 
 /**
  *
+ * @enum SequenceExportKind
+ * A collection of constant values to select among different kinds of
+ * buttons that can appear in the SequenceMenu. Each SequenceExportModule
+ * corresponds to such a button and must have one of these kinds.
+ *
+ */
+export enum SequenceExportKind {
+    GETTER,  // Produces new INSTANCES for the SequenceMenu; always
+             // listed at the bottom of the SequenceMenu
+    FAMILY,  // A single entry in the SequenceMenu that needs parameters
+             // whenever used
+    INSTANCE // A single sequence in the SequenceMenu, added by a FACTORY
+}
+/**
+ *
  * @class SequenceExportModule
  * A lightweight container for an entry in the list of sequences in the
- * menu on the main tool. Can hold either a sequence constructor or a
- * specific sequence according to whether isOeis is false or true, respectively.
+ * menu on the main tool. If the kind is GETTER or FAMILY it holds a
+ * sequence constructor and if it is an INSTANCE then it holds one
+ * specific sequence.
+ *
+ * The difference between a GETTER and a FAMILY is that the former creates
+ * a new INSTANCE selector in the menu, whereas the former starts out in the
+ * menu and you fill out the parameters each time you use it.
  *
  */
 export class SequenceExportModule{
     constructorOrSequence: SequenceConstructor|SequenceInterface;
     name: string;
-    isOeis = false;
+    kind: SequenceExportKind;
 
     constructor(sequence: SequenceConstructor|SequenceInterface,
                 name: string,
-                isOeis = false) {
+                kind: SequenceExportKind) {
         this.constructorOrSequence = sequence;
         this.name = name;
-        this.isOeis = isOeis;
+        this.kind = kind;
     }
 }

--- a/src/sequences/SequenceNaturals.ts
+++ b/src/sequences/SequenceNaturals.ts
@@ -1,5 +1,6 @@
 import { ValidationStatus } from '@/shared/ValidationStatus';
-import { SequenceParamsSchema, SequenceExportModule } from './SequenceInterface';
+import { SequenceParamsSchema, SequenceExportModule,
+         SequenceExportKind } from './SequenceInterface';
 import { SequenceCached } from './SequenceCached';
 
 /**
@@ -57,5 +58,6 @@ class SequenceNaturals extends SequenceCached {
 
 export const exportModule = new SequenceExportModule(
     SequenceNaturals,
-    "Natural Numbers"
+    "Natural Numbers",
+    SequenceExportKind.FAMILY
 );

--- a/src/views/ToolMain.vue
+++ b/src/views/ToolMain.vue
@@ -15,7 +15,7 @@
                   v-bind:sequences="sequences"
                   v-bind:activeSeq="activeSeq"
                   v-on:createSeq="setActiveSeq($event)"
-                  v-on:addOeisSeq="addOeisSeq($event)"
+                  v-on:addInstance="addInstance($event)"
                 />
                 <VizualizationMenu 
                   v-bind:visualizers="visualizers"
@@ -45,8 +45,8 @@ import CanvasArea from '@/components/CanvasArea.vue';
 import BundleManager from '@/components/BundleManager.vue';
 import visualizerS from '@/visualizers/visualizers';
 import SEQUENCES from '@/sequences/sequences';
-import { SequenceInterface,
-         SequenceExportModule } from '@/sequences/SequenceInterface';
+import { SequenceInterface, SequenceExportModule,
+         SequenceExportKind } from '@/sequences/SequenceInterface';
 import { VisualizerInterface  } from '@/visualizers/VisualizerInterface';
 
 export default Vue.extend({
@@ -64,14 +64,14 @@ export default Vue.extend({
     setActiveSeq: function(newSeq: SequenceInterface) {
         this.activeSeq = newSeq;
     },
-    addOeisSeq: function(newOeisSeq: SequenceInterface) {
+    addInstance: function(newInstance: SequenceInterface) {
       const seqBundle = new SequenceExportModule(
-        newOeisSeq,
-        newOeisSeq.name,
-        true
+        newInstance,
+        newInstance.name,
+        SequenceExportKind.INSTANCE
       )
       this.sequences.push(seqBundle);
-      this.setActiveSeq(newOeisSeq);
+      this.setActiveSeq(newInstance);
     },
     bundleSeqVizPair: function() {
         const bundle = {


### PR DESCRIPTION
  This code is a step toward resolving #23 and does not add new functionality. 

  Rather, it makes explicit the fact that there are three kinds of Sequence items:
  Sequence "Getter"s that have a button at the bottom of the sequence menu,
  which when used produces a new button for the specific sequence created;
  Sequence "Family"s that have a button in the top of the sequence menu, but
  need parameters to create a specific sequence each time their button is
  pressed; and Sequence "Instance"s that were created by a "Getter" and which
  select that one specific sequence when their button is pressed.

  Formerly, which one of these kinds a Sequence functioned as was an indirect
  result of whether it had a SequenceExportModule and whether or not "isOeis"
  was true in that module; also, the button for the only "Getter" in practice,
  the OEIS Sequence Template, was hard-coded.

  This PR creates an explicit enumeration of the three kinds, and requires that
  every Sequence object has a SequenceExportModule to show up in the Menu, and
  the kind must be explicitly set in that module.

  The motivation for this refactoring (besides code clarity and the removal
  of hard-coding for the OEIS template) is to allow for additional Getters
  besides the OEIS template, whose buttons will be automatically displayed
  alongside the OEIS one at the bottom of the Sequence menu. The idea is that
  the Sequence type to come that allows mixed formulas and OEIS sequences
  will be such a Getter.