### PR TITLE
WIP refactor proposal A: Systematize Sequence objects to return BigInt | undefined

### DIFF
--- a/src/sequences/SequenceCached.ts
+++ b/src/sequences/SequenceCached.ts
@@ -12,7 +12,7 @@ export class SequenceCached extends SequenceClassDefault {
     name = 'Cached Base';
     description = 'A base class for cached sequences';
     entries = 0;
-    protected cache: number[];
+    protected cache: bigint[];
     protected newSize = 1;
 
     /**
@@ -60,15 +60,17 @@ export class SequenceCached extends SequenceClassDefault {
 
     fillCache(): void {
         for (let i: number = this.cache.length; i < this.newSize; i++) {
-            this.cache[i] = this.calculate(i);
+            const val = this.calculate(i);
+            /* Would be type error to store in cache if undefined */
+            if (typeof val !== 'undefined') this.cache[i] = val;
         }
     }
 
-    getElement(n: number): number {
+    getElement(n: number): bigint | undefined {
         if (this.entries > 0 && n >= this.entries) {
-            return Number.NaN;
+            return;
         }
-	if (n >= this.cache.length) {
+        if (n >= this.cache.length) {
             this.resizeCache(n);
             if (this.newSize > this.cache.length) {
                 this.fillCache();
@@ -81,7 +83,8 @@ export class SequenceCached extends SequenceClassDefault {
      * calculate produces the proper value of the sequence for a given index
      * @param {number} n the index of the entry to calculate
      */
-    calculate(n: number): number {
-        return n;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    calculate(n: number): bigint | undefined {
+        return;
     }
 }

--- a/src/sequences/SequenceClassDefault.ts
+++ b/src/sequences/SequenceClassDefault.ts
@@ -41,10 +41,12 @@ export class SequenceClassDefault implements SequenceInterface {
             
     /** 
      * getElement is how sequences provide their callers with elements.
+     * Note the default sequence has no elements, and so always returns undefined
      * @param n the sequence number to get
      */
-    getElement(n: number): number {
-        return n;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getElement(n: number): bigint | undefined {
+        return;
     }
 
     /**

--- a/src/sequences/SequenceConstant.ts
+++ b/src/sequences/SequenceConstant.ts
@@ -19,7 +19,7 @@ class SequenceConstant extends SequenceClassDefault {
         false,
         '0'
     )];
-    value = -1;
+    value = -1n;
 
     constructor(ID: number) {
         super(ID);
@@ -34,7 +34,7 @@ class SequenceConstant extends SequenceClassDefault {
 
         if (this.settings['constantValue'] !== undefined) {
             this.isValid = true;
-            this.value = Number(this.settings['constantValue']);
+            this.value = BigInt(this.settings['constantValue']);
             this.name = 'Constant = ' + this.settings['constantValue'];
             return new ValidationStatus(true);
         }

--- a/src/sequences/SequenceFormula.ts
+++ b/src/sequences/SequenceFormula.ts
@@ -68,7 +68,7 @@ class SequenceFormula extends SequenceCached {
     }
 
     calculate(n: number) {
-        return this.formula.evaluate({n: n});
+        return BigInt(this.formula.evaluate({n: n}));
     }
 
 }

--- a/src/sequences/SequenceInterface.ts
+++ b/src/sequences/SequenceInterface.ts
@@ -43,14 +43,16 @@ export interface SequenceInterface {
     initialize(): void;
 
     /**
-     * Get element is what the drawing tools will be calling, it retrieves
-     * the nth element of the sequence by either getting it from the cache
-     * or if isn't present, by building the cache and then getting it
+     * getElement is what the drawing tools will be calling. It retrieves
+     * the nth element of the sequence; if there is no such element (i.e., the
+     * sequence has no nth term), it returns "undefined." The latter value is
+     * chosen because narrowing the type away from undefined is probably just
+     * a bit easier in TypeScript.
      * @param {*} n the index of the element in the sequence we want
      * @returns a number
      * @memberof SequenceGenerator
      */
-    getElement(n: number): number;
+    getElement(n: number): bigint | undefined;
 
     validate(): ValidationStatus;
 }

--- a/src/sequences/SequenceNaturals.ts
+++ b/src/sequences/SequenceNaturals.ts
@@ -19,7 +19,7 @@ class SequenceNaturals extends SequenceCached {
         false,
         false
     )];
-    private offset = 1;
+    private offset = 1n;
 
     /**
      *Creates an instance of SequenceNaturals
@@ -40,7 +40,7 @@ class SequenceNaturals extends SequenceCached {
             this.isValid = true;
             this.name = "Positive Integers";
             if (this.settings['includeZero']) {
-                this.offset = 0;
+                this.offset = 0n;
                 this.name = "Nonnegative Integers";
             }
             return new ValidationStatus(true);
@@ -51,7 +51,7 @@ class SequenceNaturals extends SequenceCached {
     }
 
     calculate(n: number) {
-        return n + this.offset;
+        return BigInt(n) + this.offset;
     }
 
 }

--- a/src/visualizers/VisualizerDifferences.ts
+++ b/src/visualizers/VisualizerDifferences.ts
@@ -2,6 +2,7 @@ import { SequenceInterface } from "@/sequences/SequenceInterface";
 import { VisualizerInterface, VisualizerParamsSchema, VisualizerSettings, VisualizerExportModule } from "@/visualizers/VisualizerInterface";
 import { ParamType } from '@/shared/ParamType';
 import { VisualizerDefault } from './VisualizerDefault';
+import { minus } from './math';
 import { ValidationStatus } from '@/shared/ValidationStatus';
 
 class VizDifferences extends VisualizerDefault implements VisualizerInterface {
@@ -67,11 +68,14 @@ class VizDifferences extends VisualizerDefault implements VisualizerInterface {
 			hue = (i * 255 / 6) % 255;
 			myColor = this.sketch.color(hue, 150, 200);
 			this.sketch.fill(myColor);
+			/* Draw and update workingSequence: */
 			for (let j = 0; j < workingSequence.length; j++) {
-				this.sketch.text(workingSequence[j], firstX + j * xDelta, firstY + i * yDelta); //Draws and updates workingSequence simultaneously.
-				if (j < workingSequence.length - 1) {
-					workingSequence[j] = workingSequence[j + 1] - workingSequence[j];
-				}
+				const tx = workingSequence[j]?.toString() ?? '-';
+				this.sketch.text(tx, firstX + j * xDelta,
+						firstY + i * yDelta);
+				if (j == workingSequence.length - 1) continue;
+				workingSequence[j] = minus(workingSequence[j+1],
+							workingSequence[j]);
 			}
 
 			workingSequence.pop();

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -47,7 +47,7 @@ export class VisualizerParamsSchema {
 
 
 export interface VisualizerSettings {
-	[key: string]: string | number | boolean;
+	[key: string]: string | number | bigint | boolean;
 }
 
 export interface VisualizerInterface {

--- a/src/visualizers/VisualizerModFill.ts
+++ b/src/visualizers/VisualizerModFill.ts
@@ -50,8 +50,8 @@ class VizModFill extends VisualizerDefault implements VisualizerInterface {
 		let j;
 		for (let mod = 1; mod <= this.settings.modDimension; mod++) {
 			const el = seq.getElement(num);
-			if(el === undefined) break;
-			i = el % mod;
+			if (el === undefined) break;
+			i = Number(el % BigInt(mod));
 			j = mod - 1;
 			this.sketch.rect(j * this.rectWidth, this.sketch.height - (i + 1) * this.rectHeight, this.rectWidth, this.rectHeight);
 		}

--- a/src/visualizers/VisualizerShiftCompare.ts
+++ b/src/visualizers/VisualizerShiftCompare.ts
@@ -16,7 +16,7 @@ class VizShiftCompare extends VisualizerDefault implements VisualizerInterface {
 		"Mod factor",
 		true,
 		2,
-		"The shift that will be applied"
+		"The modulus used for comparing terms"
 	)];
 
 	constructor(){
@@ -53,63 +53,61 @@ class VizShiftCompare extends VisualizerDefault implements VisualizerInterface {
 
 
     //This will be called everytime to draw
-	draw() { 
-		// Ensure mouse coordinates are sane.
-		// Mouse coordinates look they're floats by default.
+    draw() {
+        // Ensure mouse coordinates are sane.
+        // Mouse coordinates look they're floats by default.
         console.log('drawing');
         console.log(this.img.pixels.length);
-		let mod = Number(this.settings.mod);
+        let mod = BigInt(this.settings.mod);
 
-		const d = this.sketch.pixelDensity();
-		const mx = this.clip(Math.round(this.sketch.mouseX), 0, this.sketch.width);
-		const my = this.clip(Math.round(this.sketch.mouseY), 0, this.sketch.height);
-		if (this.sketch.key == 'ArrowUp') {
-            mod += 1;
-			this.sketch.key = '';
-			console.log("UP PRESSED, NEW MOD: " + mod);
-		} else if (this.sketch.key == 'ArrowDown') {
-            mod -= 1;
-			this.sketch.key = '';
-			console.log("DOWN PRESSED, NEW MOD: " + mod);
-		} else if (this.sketch.key == 'ArrowRight') {
-			console.log(console.log("MX: " + mx + " MY: " + my));
-		}
+        const d = this.sketch.pixelDensity();
+        const mx = this.clip(Math.round(this.sketch.mouseX), 0, this.sketch.width);
+        const my = this.clip(Math.round(this.sketch.mouseY), 0, this.sketch.height);
+        if (this.sketch.key == 'ArrowUp') {
+            mod += 1n;
+            this.sketch.key = '';
+            console.log("UP PRESSED, NEW MOD: " + mod);
+        } else if (this.sketch.key == 'ArrowDown') {
+            mod -= 1n;
+            this.sketch.key = '';
+            console.log("DOWN PRESSED, NEW MOD: " + mod);
+        } else if (this.sketch.key == 'ArrowRight') {
+            console.log(console.log("MX: " + mx + " MY: " + my));
+        }
         // since settings.mod can be any of string | number | bool, 
         // first set mod which is always a number, then assign it here to avoid typing errors
         this.settings.mod = mod;
-		// Write to image, then to screen for speed.
-		for (let x = 0; x < this.sketch.width; x++) {
+        // Write to image, then to screen for speed.
+        for (let x = 0; x < this.sketch.width; x++) {
             const xEl = this.seq.getElement(x);
+            if (xEl === undefined) break;
             for (let y = 0; y < this.sketch.height; y++) {
-            const yEl = this.seq.getElement(y);
-				for (let i = 0; i < d; i++) {
-					for (let j = 0; j < d; j++) {
-						const index = 4 * ((y * d + j) * this.sketch.width * d + (x * d + i));
+                const yEl = this.seq.getElement(y);
+                if (yEl === undefined) break;
+                for (let i = 0; i < d; i++) {
+                    for (let j = 0; j < d; j++) {
+                        const index = 4 * ((y * d + j) * this.sketch.width * d + (x * d + i));
                         console.log('x,y: ' + xEl + ', ' + yEl);
-						if(xEl === undefined || yEl === undefined) {
-                            this.sketch.noLoop();
-                            return;
+                        if (xEl % mod == yEl % mod) {
+                            this.img.pixels[index] = 255;
+                            this.img.pixels[index + 1] = 255;
+                            this.img.pixels[index + 2] = 255;
+                            this.img.pixels[index + 3] = 255;
+                        } else {
+                            this.img.pixels[index] = 0;
+                            this.img.pixels[index + 1] = 0;
+                            this.img.pixels[index + 2] = 0;
+                            this.img.pixels[index + 3] = 255;
                         }
-						if (xEl % mod == yEl % mod) {
-							this.img.pixels[index] = 255;
-							this.img.pixels[index + 1] = 255;
-							this.img.pixels[index + 2] = 255;
-							this.img.pixels[index + 3] = 255;
-						} else {
-							this.img.pixels[index] = 0;
-							this.img.pixels[index + 1] = 0;
-							this.img.pixels[index + 2] = 0;
-							this.img.pixels[index + 3] = 255;
-						}
-					}
-				}
-			}
-		}
+                    }
+                }
+            }
+        }
 
-		this.img.updatePixels(); // Copies our edited pixels to the image.
+        this.img.updatePixels(); // Copies our edited pixels to the image.
 
-		this.sketch.image(this.img, 0, 0); // Display image to screen.this.sketch.line(50,50,100,100);
-	}
+        this.sketch.image(this.img, 0, 0); // Display image to screen.this.sketch.line(50,50,100,100);
+    }
 }
 
 

--- a/src/visualizers/VisualizerTurtle.ts
+++ b/src/visualizers/VisualizerTurtle.ts
@@ -12,7 +12,7 @@ const schemaTurtle = [
 		'Sequence Domain',
 		true,
 		"0,1,2,3,4",
-		'Comma seperated numbers',
+		'Comma-separated numbers',
 	),
 	new VisualizerParamsSchema(
 		"range",
@@ -20,7 +20,7 @@ const schemaTurtle = [
 		'Angles',
 		true,
 		"30,45,60,90,120",
-		'Comma seperated numbers',
+		'Comma-separated numbers',
 	),
 	new VisualizerParamsSchema(
 		"stepSize",
@@ -130,19 +130,19 @@ class VisualizerTurtle extends VisualizerDefault implements VisualizerInterface 
 	}
 
 	draw() {
-		const currElement = this.seq.getElement(this.currentIndex++);
-		const angle = this.rotMap[currElement];
+		const elt = Number(this.seq.getElement(this.currentIndex++));
+		const angle = this.rotMap[elt];
 
 		if (angle == undefined) this.sketch.noLoop();
 
-        const oldX = this.X;
-        const oldY = this.Y;
+		const oldX = this.X;
+		const oldY = this.Y;
 
-        this.orientation = (this.orientation + angle);
-        this.X += Number(this.settings.stepSize) * Math.cos(this.orientation);
-        this.Y += Number(this.settings.stepSize) * Math.sin(this.orientation);
+		this.orientation = (this.orientation + angle);
+		this.X += Number(this.settings.stepSize) * Math.cos(this.orientation);
+		this.Y += Number(this.settings.stepSize) * Math.sin(this.orientation);
 
-        this.sketch.line(oldX,oldY,this.X,this.Y);
+		this.sketch.line(oldX,oldY,this.X,this.Y);
 	}
 }
 

--- a/src/visualizers/math.ts
+++ b/src/visualizers/math.ts
@@ -1,0 +1,10 @@
+/* minus() takes two optional inputs and returns undefined if either
+   is undefined, and the first minus the second otherwise
+   @param left  the first operand
+   @param right the second operand
+ */ 
+export function minus(left?: bigint, right?: bigint): bigint|undefined {
+    if (typeof right === 'undefined') return undefined;
+    if (typeof left === 'undefined') return undefined;
+    return left-right;
+}


### PR DESCRIPTION
  Resolves #42.

  Note this also creates the math.ts collection of functions for use by visualizer writers as called for in #48. It turns out Sequences in fact have to return the union `bigint | undefined` because otherwise there is no way to flag nonexistent sequence values. That makes arithmetic on the return values kind of a pain. Since we are going to have a math module anyway, though, we should just put in there utility functions that handle undefined values in the straightforward way of making results undefined whenever any inputs are undefined.