### PR TITLE
refactor: Sequence getElement consistently returns BigInt

### DIFF
--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -23,12 +23,12 @@ export default class OEISSequenceTemplate extends SequenceCached {
         new SequenceParamsSchema('modulo', 'number', 'Modulo to apply to the sequence', false, false)
     ];
 
-    constructor(ID: number) {
-	super(ID); // Don't know the index range yet, will fill in later
+    constructor(sequenceID: number) {
+        super(sequenceID); // Don't know the index range yet, will fill in later
     }
 
     fillCache(): void {
-        axios.get(`http://${process.env.VUE_APP_API_URL}/api/get_oeis_sequence/${this.settings.oeisId}/${this.blocksize}`)
+        axios.get(`http://${process.env.VUE_APP_API_URL}/api/get_oeis_sequence/${this.settings.oeisId}/${this.cacheBlock}`)
              .then( resp => {
                  if (this.settings.modulo) {
                      this.cache = resp.data.values.map((x: string) => BigInt(x) % BigInt(this.settings.modulo));
@@ -51,20 +51,20 @@ export default class OEISSequenceTemplate extends SequenceCached {
             return superStatus;
         }
 
-        if (this.settings['oeisId'] !== undefined) {
-            this.isValid = true;
-            if (this.settings['numElements']) {
-                this.last = Number(this.settings['numElements']) - 1;
-            } else {
-                this.last = 999;
-            }
-            this.blocksize = this.last + 1; // get everything on the initial fill
-            this.name = (this.settings['name'] as string);
-            return new ValidationStatus(true);
+        this.isValid = false;
+        if (this.settings['oeisId'] === undefined) {
+            return new ValidationStatus(false, ["oeisID parameter is missing"]);
         }
 
-        this.isValid = false;
-        return new ValidationStatus(false, ["oeisID parameter is missing"]);
+        this.isValid = true;
+        if (this.settings['numElements']) {
+            this.last = Number(this.settings['numElements']) - 1;
+        } else {
+            this.last = 999;
+        }
+        this.cacheBlock = this.last + 1; // get everything on the initial fill
+        this.name = (this.settings['name'] as string);
+        return new ValidationStatus(true);
     }
 
 }

--- a/src/sequences/SequenceCached.ts
+++ b/src/sequences/SequenceCached.ts
@@ -1,12 +1,15 @@
 import { SequenceClassDefault } from './SequenceClassDefault';
 
+const min = Math.min;
+const max = Math.max;
+
 /**
  *
  * @class SequenceCached
  * extends the sequenceClassDefault with a facility to cache pre-computed
- * entries in the sequence. Intended as a base class for sequence
- * implementations that want to cache their entries. Derived classes
- * just need to override the calculate() method.
+ * entries in the sequence. Sequences may derive from it and override just
+ * the (dummy) calculate() method supplied here, and the caching will
+ * automatically occur.
  *
  * Note: to prevent bugs with sequences with non-deterministic formulae
  * (e.g. in SequenceRandom.ts), this class should guarantee that
@@ -16,77 +19,78 @@ import { SequenceClassDefault } from './SequenceClassDefault';
 export class SequenceCached extends SequenceClassDefault {
     name = 'Cached Base';
     description = 'A base class for cached sequences';
-    entries = 0;
-    protected cache: number[];
-    protected newSize = 1;
+    protected cache: bigint[] = [];
+    protected lastCached: number;
+    protected cachingTo: number;
+    protected blocksize: number;
 
     /**
      *Creates an instance of SequenceCached.
      * @param {*} ID the ID of the sequence
-     * @param {number} max_entries specifies the maximum number of entries. Defaults to 0, which means no maximum, if not given.
+     * @param {number} first specifies the smallest valid index of the series; defaults to 0
+     * @param {number} last specifies the largest valid index of the series; defaults to Infinity.
+     * @param {number} blocksize specifies how many values to put in cache at each additonal fill; defaults to 128.
      */
-    constructor (ID: number, max_entries?: number) {
+    constructor (ID: number,
+                 first?: number, last?: number, blocksize?:number) {
         super(ID);
-	if (max_entries !== undefined) {
-            this.entries = max_entries;
-	}
-        this.cache = [];
+        this.first = first ?? 0;
+        this.last = last ?? Infinity;
+        this.blocksize = blocksize ?? 128;
+        this.lastCached = this.first - 1;
+        this.cachingTo = this.lastCached;
     }
 
     initialize(): void {
         if (this.ready) return;
-        if (this.isValid) {
-            if (this.entries > 0) {
-                this.newSize = this.entries;
-		if (this.newSize > 100) this.newSize = 100;
-            } else {
-                this.newSize = 100;
-            }
-            this.fillCache();
-            this.ready = true;
-            return;
-        }
-
-        throw "Sequence is not valid. Run validate and address any errors."
+        super.initialize();
+        this.ready = false;
+        this.cachingTo = min(this.lastCached + this.blocksize, this.last);
+        this.fillCache();
+        this.ready = true;
     }
 
     resizeCache(n: number): void {
-        this.newSize = this.cache.length * 2;
-        if (this.newSize < 100) {
-            this.newSize = 100;
-        }
-        if (n + 1 > this.newSize) {
-            this.newSize = n + 1;
-        }
-	if (this.entries > 0 && this.newSize > this.entries) {
-            this.newSize = this.entries;
-        }
+        this.cachingTo = max(this.lastCached + this.blocksize,
+                             2*this.lastCached, n+1)
+        if (this.cachingTo > this.last) this.cachingTo = this.last;
     }
 
     fillCache(): void {
-        for (let i: number = this.cache.length; i < this.newSize; i++) {
+        for (let i: number = this.lastCached+1; i <= this.cachingTo; i++) {
             this.cache[i] = this.calculate(i);
+            this.lastCached = i;
         }
     }
 
-    getElement(n: number): number {
-        if (this.entries > 0 && n >= this.entries) {
-            return Number.NaN;
+    getElement(n: number): bigint {
+        if (n < this.first || n > this.last) {
+            throw RangeError(
+                `Cached: Index ${n} not in ${this.first}..${this.last}.`);
         }
-	if (n >= this.cache.length) {
-            this.resizeCache(n);
-            if (this.newSize > this.cache.length) {
-                this.fillCache();
-            }
-	}
+        if (n <= this.lastCached) {
+            return this.cache[n];
+        }
+        /* Check for a race condition: attempting to get a value while it's
+           in the midst of being cached. It's also possible this could
+           occur if a prior fillCache() threw an uncaught exception, for
+           example.
+         */
+        if (this.lastCached != this.cachingTo) {
+            throw Error(
+                `Currently caching ${this.lastCached} to ${this.cachingTo}.`);
+        }
+        this.resizeCache(n);
+        this.fillCache();
         return this.cache[n];
     }
 
     /**
      * calculate produces the proper value of the sequence for a given index
+     * This should be overridden in any derived class.
      * @param {number} n the index of the entry to calculate
      */
-    calculate(n: number): number {
-        return n;
+    calculate(n: number): bigint {
+        return BigInt(n);
     }
 }

--- a/src/sequences/SequenceClassDefault.ts
+++ b/src/sequences/SequenceClassDefault.ts
@@ -5,7 +5,7 @@ import { ValidationStatus } from '@/shared/ValidationStatus';
  *
  * @class SequenceClassDefault
  * a minimium working example of a sequence class that implements the interface
- * Can be used as a base class for your own sequences.
+ * Primarily intended to be used as a base class for your own sequences.
  * 
  */
 export class SequenceClassDefault implements SequenceInterface {
@@ -13,6 +13,8 @@ export class SequenceClassDefault implements SequenceInterface {
     name = 'Base';
     description = 'A Base sequence class';
     params: SequenceParamsSchema[] = [new SequenceParamsSchema('name', '', 'displayName', false, '0')];
+    first = 0;
+    last = 0;
     ready: boolean;
     isValid: boolean;
 
@@ -31,20 +33,28 @@ export class SequenceClassDefault implements SequenceInterface {
      */
     initialize(): void {
         if (this.ready) return;
+        if (this.first < Number.MIN_SAFE_INTEGER
+            || this.first > Number.MAX_SAFE_INTEGER) {
+            throw Error('Sequence first index must be a safe integer');
+        }
         if (this.isValid) {
             this.ready = true;
             return
-        } else {
-            throw "Sequence is not valid. Run validate() and address any errors."
         }
+        throw Error('Sequence invalid. Run validate and address any errors.');
     }
             
     /** 
      * getElement is how sequences provide their callers with elements.
+     * This default implementation produces the not-very-useful sequence with
+     * one element, 0, at index 0.
      * @param n the sequence number to get
      */
-    getElement(n: number): number {
-        return n;
+    getElement(n: number): bigint {
+        if (n !== 0) {
+            throw RangeError(`SequenceClassDefault: Index ${n} != 0 invalid`);
+        }
+        return 0n;
     }
 
     /**
@@ -66,3 +76,9 @@ export class SequenceClassDefault implements SequenceInterface {
         return new ValidationStatus(true, ["name param is undefined."]);
     }
 }
+
+/* For a Sequence implementation to appear as an option in the main tool,
+ * it needs a SequenceExportModule defined along with its class. Since
+ * this default implementation is not intended for actual use, there is
+ * not one here.
+ */

--- a/src/sequences/SequenceClassDefault.ts
+++ b/src/sequences/SequenceClassDefault.ts
@@ -9,7 +9,7 @@ import { ValidationStatus } from '@/shared/ValidationStatus';
  * 
  */
 export class SequenceClassDefault implements SequenceInterface {
-    ID: number;
+    sequenceID: number;
     name = 'Base';
     description = 'A Base sequence class';
     params: SequenceParamsSchema[] = [new SequenceParamsSchema('name', '', 'displayName', false, '0')];
@@ -20,8 +20,8 @@ export class SequenceClassDefault implements SequenceInterface {
 
     protected settings: { [key: string]: string|number|boolean} = {};
 
-    constructor(ID: number) {
-        this.ID = ID;
+    constructor(sequenceID: number) {
+        this.sequenceID = sequenceID;
         this.ready = false;
         this.isValid = false;
     }

--- a/src/sequences/SequenceConstant.ts
+++ b/src/sequences/SequenceConstant.ts
@@ -23,8 +23,8 @@ class SequenceConstant extends SequenceClassDefault {
     last = Infinity;
     value = -1n;
 
-    constructor(ID: number) {
-        super(ID);
+    constructor(sequenceID: number) {
+        super(sequenceID);
     }
 
     validate(): ValidationStatus {

--- a/src/sequences/SequenceConstant.ts
+++ b/src/sequences/SequenceConstant.ts
@@ -11,15 +11,17 @@ import { SequenceClassDefault } from './SequenceClassDefault';
  */
 class SequenceConstant extends SequenceClassDefault {
     name = "Constant Sequence";
-    description = "A sequence that is constant";
+    description = "A sequence with the same value for all nonnegative indices";
     params = [new SequenceParamsSchema(
         'constantValue',
         'number',
         'Constant Value',
-        false,
+        true,
         '0'
     )];
-    value = -1;
+    first = 0;
+    last = Infinity;
+    value = -1n;
 
     constructor(ID: number) {
         super(ID);
@@ -34,7 +36,7 @@ class SequenceConstant extends SequenceClassDefault {
 
         if (this.settings['constantValue'] !== undefined) {
             this.isValid = true;
-            this.value = Number(this.settings['constantValue']);
+            this.value = BigInt(this.settings['constantValue']);
             this.name = 'Constant = ' + this.settings['constantValue'];
             return new ValidationStatus(true);
         }
@@ -43,8 +45,10 @@ class SequenceConstant extends SequenceClassDefault {
         return new ValidationStatus(false, ["No constant value was provided."]);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getElement(n: number) {
+        if (n < 0) {
+            throw RangeError('SequenceConstant requires nonnegative index.');
+        }
         return this.value;
     }
 }

--- a/src/sequences/SequenceFormula.ts
+++ b/src/sequences/SequenceFormula.ts
@@ -8,7 +8,9 @@ import * as math from 'mathjs';
  *
  * @class SequenceFormula
  * extends SequenceCached to use mathjs to compute an arbitrary formula in terms
- * of n.
+ * of n. Currently all such formulas start at index 0 and have no limit, but
+ * those are both arbitrary choices; we might at some point want to allow
+ * either to be tailored.
  */
 class SequenceFormula extends SequenceCached {
     name = "Formula: empty";
@@ -17,7 +19,7 @@ class SequenceFormula extends SequenceCached {
         'formula',
         'text',
         'Formula',
-        false,
+        true,
         'n'
     )];
 
@@ -68,7 +70,7 @@ class SequenceFormula extends SequenceCached {
     }
 
     calculate(n: number) {
-        return this.formula.evaluate({n: n});
+        return BigInt(this.formula.evaluate({n: n}));
     }
 
 }

--- a/src/sequences/SequenceFormula.ts
+++ b/src/sequences/SequenceFormula.ts
@@ -27,10 +27,10 @@ class SequenceFormula extends SequenceCached {
 
     /**
      *Creates an instance of SequenceFormula
-     * @param {*} ID the ID of the sequence
+     * @param {*} sequenceID the sequence identifer of the sequence
      */
-    constructor (ID: number) {
-        super(ID);
+    constructor (sequenceID: number) {
+        super(sequenceID);
         this.formula = math.compile('n'); // tide us over until validate()
     }
 

--- a/src/sequences/SequenceInterface.ts
+++ b/src/sequences/SequenceInterface.ts
@@ -28,7 +28,7 @@ export class SequenceParamsSchema {
  * with Numberscope.
  */
 export interface SequenceInterface {
-    ID: number;
+    sequenceID: number;
     name: string;
     description: string;
     params: SequenceParamsSchema[];
@@ -72,7 +72,7 @@ export interface SequenceInterface {
 }
 
 export interface SequenceConstructor {
-    new (ID: number): SequenceInterface;
+    new (sequenceID: number): SequenceInterface;
 }
 
 /**

--- a/src/sequences/SequenceInterface.ts
+++ b/src/sequences/SequenceInterface.ts
@@ -32,6 +32,21 @@ export interface SequenceInterface {
     name: string;
     description: string;
     params: SequenceParamsSchema[];
+    /**
+     * first gives the lower limit for valid indices into the Sequence.
+     * In other words, an integer number n is a valid index only if
+     * first <= n. The typical value is 0, but any finite (positive or
+     * negative) integer value is allowed.
+     */
+    readonly first: number;
+    /**
+     * last is the counterpart to first, giving the upper limit for valid
+     * indices into the Sequence. An integer number n is a valid index
+     * if and only if first <= n <= last. Hence, if last is less than first,
+     * the sequence is empty; if last is (the Javascript number) Infinity,
+     * all indices not less than first are valid.
+     */
+    readonly last: number;
 
     /**
      * Initialize is called after params are set. It allows us to wait until all the settings
@@ -43,14 +58,15 @@ export interface SequenceInterface {
     initialize(): void;
 
     /**
-     * Get element is what the drawing tools will be calling, it retrieves
-     * the nth element of the sequence by either getting it from the cache
-     * or if isn't present, by building the cache and then getting it
+     * getElement is what clients of SequenceInterface call to get
+     * the actual entries in the sequence. It retrieves the nth element
+     * of the sequence, so long as n is an integer between
+     * the SequenceInterface.first and .last indices, inclusive.
      * @param {*} n the index of the element in the sequence we want
      * @returns a number
      * @memberof SequenceGenerator
      */
-    getElement(n: number): number;
+    getElement(n: number): bigint;
 
     validate(): ValidationStatus;
 }

--- a/src/sequences/SequenceNaturals.ts
+++ b/src/sequences/SequenceNaturals.ts
@@ -23,10 +23,10 @@ class SequenceNaturals extends SequenceCached {
 
     /**
      *Creates an instance of SequenceNaturals
-     * @param {*} ID the ID of the sequence
+     * @param {*} sequenceID the sequence identifier of the sequence
      */
-    constructor (ID: number) {
-        super(ID);
+    constructor (sequenceID: number) {
+        super(sequenceID);
     }
 
     validate(){

--- a/src/sequences/SequenceNaturals.ts
+++ b/src/sequences/SequenceNaturals.ts
@@ -19,7 +19,7 @@ class SequenceNaturals extends SequenceCached {
         false,
         false
     )];
-    private offset = 1;
+    private begin = 1;
 
     /**
      *Creates an instance of SequenceNaturals
@@ -30,7 +30,7 @@ class SequenceNaturals extends SequenceCached {
     }
 
     validate(){
-        this.settings['name'] = 'Constant';
+        this.settings['name'] = 'Initializing Naturals...';
         const superStatus = super.validate();
         if (!superStatus.isValid) {
             return superStatus;
@@ -40,7 +40,7 @@ class SequenceNaturals extends SequenceCached {
             this.isValid = true;
             this.name = "Positive Integers";
             if (this.settings['includeZero']) {
-                this.offset = 0;
+                this.begin = 0;
                 this.name = "Nonnegative Integers";
             }
             return new ValidationStatus(true);
@@ -51,7 +51,7 @@ class SequenceNaturals extends SequenceCached {
     }
 
     calculate(n: number) {
-        return n + this.offset;
+        return BigInt(n + this.begin);
     }
 
 }

--- a/src/sequences/SequenceRandom.ts
+++ b/src/sequences/SequenceRandom.ts
@@ -7,7 +7,7 @@ import { SequenceCached } from './SequenceCached';
  *
  * @class SequenceClassRandom
  * Creates a sequence of random integers in a specified range.
- *
+ * Starts at index 0 and has no limit.
  */
 class SequenceRandom extends SequenceCached {
 	name = "Random Integers in Range";
@@ -64,7 +64,7 @@ class SequenceRandom extends SequenceCached {
 
 	calculate(n: number) {   // eslint-disable-line @typescript-eslint/no-unused-vars
 		// create a random integer between min and max inclusive
-		return Math.floor((Math.random() * (this.maximum - this.minimum + 1)) + this.minimum);
+		return BigInt(Math.floor((Math.random() * (this.maximum - this.minimum + 1)) + this.minimum));
 	}
 
 }

--- a/src/sequences/SequenceRandom.ts
+++ b/src/sequences/SequenceRandom.ts
@@ -32,10 +32,10 @@ class SequenceRandom extends SequenceCached {
 
 	/**
 	*Creates an instance of SequenceRandom
-	* @param {*} ID the ID of the sequence
+	* @param {*} sequenceID the sequence identifier of the sequence
 	*/
-	constructor (ID: number) {
-		super(ID);
+	constructor (sequenceID: number) {
+		super(sequenceID);
 	}
 
 	validate(){

--- a/src/visualizers/VisualizerDifferences.ts
+++ b/src/visualizers/VisualizerDifferences.ts
@@ -45,7 +45,7 @@ class VizDifferences extends VisualizerDefault implements VisualizerInterface {
 		super.initialize(sketch, seq);
 		if (seq.last - seq.first < this.settings.levels)
 		{
-			throw Error(`Sequence ${seq.name} has too few entries`
+			throw Error(`Sequence ${seq.name} has too few entries `
 					+ `for ${this.settings.levels} levels.`);
 		}
 	}
@@ -80,7 +80,7 @@ class VizDifferences extends VisualizerDefault implements VisualizerInterface {
 			hue = (i * 255 / 6) % 255;
 			myColor = this.sketch.color(hue, 150, 200);
 			this.sketch.fill(myColor);
-			/* Draws and update workingSequence: */
+			/* Draw the row, updating workingSequence: */
 			for (let j = 0; j < workingSequence.length; j++) {
 				this.sketch.text(workingSequence[j].toString(),
 							firstX + j * xDelta,

--- a/src/visualizers/VisualizerModFill.ts
+++ b/src/visualizers/VisualizerModFill.ts
@@ -50,11 +50,11 @@ class VizModFill extends VisualizerDefault implements VisualizerInterface {
 			mod <= BigInt(this.settings.modDimension);
 			mod++)
 		{
-			const el = seq.getElement(num);
-			const xpos = Number(mod-1n) * this.rectWidth;
-			const ypos = this.sketch.height
-				- Number(el % mod + 1n) * this.rectHeight;
-			this.sketch.rect(xpos, ypos,
+			const s = seq.getElement(num);
+			const x = Number(mod-1n) * this.rectWidth;
+			const y = this.sketch.height
+				- Number(s % mod + 1n) * this.rectHeight;
+			this.sketch.rect(x, y,
 				this.rectWidth, this.rectHeight);
 		}
 

--- a/src/visualizers/VisualizerModFill.ts
+++ b/src/visualizers/VisualizerModFill.ts
@@ -46,14 +46,16 @@ class VizModFill extends VisualizerDefault implements VisualizerInterface {
 	drawNew(num: number, seq: SequenceInterface) {
 		const black = this.sketch.color(0);
 		this.sketch.fill(black);
-		let i: number;
-		let j;
-		for (let mod = 1; mod <= this.settings.modDimension; mod++) {
+		for (let mod = 1n;
+			mod <= BigInt(this.settings.modDimension);
+			mod++)
+		{
 			const el = seq.getElement(num);
-			if(el === undefined) break;
-			i = el % mod;
-			j = mod - 1;
-			this.sketch.rect(j * this.rectWidth, this.sketch.height - (i + 1) * this.rectHeight, this.rectWidth, this.rectHeight);
+			const xpos = Number(mod-1n) * this.rectWidth;
+			const ypos = this.sketch.height
+				- Number(el % mod + 1n) * this.rectHeight;
+			this.sketch.rect(xpos, ypos,
+				this.rectWidth, this.rectHeight);
 		}
 
 	}
@@ -63,13 +65,13 @@ class VizModFill extends VisualizerDefault implements VisualizerInterface {
 		this.rectWidth = this.sketch.width / modDimension;
 		this.rectHeight = this.sketch.height / modDimension;
 		this.sketch.noStroke();
-		this.i = 0;
+		this.i = this.seq.first;
 	}
 
 	draw() {
 		this.drawNew(this.i, this.seq);
 		this.i++;
-		if (this.i == 1000) {
+		if (this.i == 1000 || this.i > this.seq.last) {
 			this.sketch.noLoop();
 		}
 	}

--- a/src/visualizers/VisualizerShiftCompare.ts
+++ b/src/visualizers/VisualizerShiftCompare.ts
@@ -58,17 +58,17 @@ class VizShiftCompare extends VisualizerDefault implements VisualizerInterface {
 		// Mouse coordinates look they're floats by default.
         console.log('drawing');
         console.log(this.img.pixels.length);
-		let mod = Number(this.settings.mod);
+		let mod = BigInt(this.settings.mod);
 
 		const d = this.sketch.pixelDensity();
 		const mx = this.clip(Math.round(this.sketch.mouseX), 0, this.sketch.width);
 		const my = this.clip(Math.round(this.sketch.mouseY), 0, this.sketch.height);
 		if (this.sketch.key == 'ArrowUp') {
-            mod += 1;
+            mod += 1n;
 			this.sketch.key = '';
 			console.log("UP PRESSED, NEW MOD: " + mod);
 		} else if (this.sketch.key == 'ArrowDown') {
-            mod -= 1;
+            mod -= 1n;
 			this.sketch.key = '';
 			console.log("DOWN PRESSED, NEW MOD: " + mod);
 		} else if (this.sketch.key == 'ArrowRight') {
@@ -76,20 +76,19 @@ class VizShiftCompare extends VisualizerDefault implements VisualizerInterface {
 		}
         // since settings.mod can be any of string | number | bool, 
         // first set mod which is always a number, then assign it here to avoid typing errors
-        this.settings.mod = mod;
-		// Write to image, then to screen for speed.
-		for (let x = 0; x < this.sketch.width; x++) {
+        this.settings.mod = Number(mod);
+        const xLim = Math.min(this.sketch.width - 1, this.seq.last);
+        const yLim = Math.min(this.sketch.height - 1, this.seq.last);
+
+        // Write to image, then to screen for speed.
+        for (let x = this.seq.first; x <= xLim; x++) {
             const xEl = this.seq.getElement(x);
-            for (let y = 0; y < this.sketch.height; y++) {
+            for (let y = this.seq.first; y <= yLim; y++) {
             const yEl = this.seq.getElement(y);
 				for (let i = 0; i < d; i++) {
 					for (let j = 0; j < d; j++) {
 						const index = 4 * ((y * d + j) * this.sketch.width * d + (x * d + i));
                         console.log('x,y: ' + xEl + ', ' + yEl);
-						if(xEl === undefined || yEl === undefined) {
-                            this.sketch.noLoop();
-                            return;
-                        }
 						if (xEl % mod == yEl % mod) {
 							this.img.pixels[index] = 255;
 							this.img.pixels[index + 1] = 255;

--- a/src/visualizers/VisualizerTurtle.ts
+++ b/src/visualizers/VisualizerTurtle.ts
@@ -90,7 +90,7 @@ class VisualizerTurtle extends VisualizerDefault implements VisualizerInterface 
         this.sketch = sketch;
 		this.seq = seq;
 		
-		this.currentIndex = 0;
+		this.currentIndex = seq.first;
 		this.orientation = 0;
 		this.X = 0;
 		this.Y = 0;
@@ -130,7 +130,7 @@ class VisualizerTurtle extends VisualizerDefault implements VisualizerInterface 
 	}
 
 	draw() {
-		const currElement = this.seq.getElement(this.currentIndex++);
+        const currElement = Number(this.seq.getElement(this.currentIndex++));
 		const angle = this.rotMap[currElement];
 
 		if (angle == undefined) this.sketch.noLoop();
@@ -143,6 +143,7 @@ class VisualizerTurtle extends VisualizerDefault implements VisualizerInterface 
         this.Y += Number(this.settings.stepSize) * Math.sin(this.orientation);
 
         this.sketch.line(oldX,oldY,this.X,this.Y);
+        if (this.currentIndex > this.seq.last) this.sketch.noLoop();
 	}
 }
 

--- a/src/visualizers/VisualizerTurtle.ts
+++ b/src/visualizers/VisualizerTurtle.ts
@@ -129,11 +129,11 @@ class VisualizerTurtle extends VisualizerDefault implements VisualizerInterface 
         this.sketch.frameRate(30);
 	}
 
-	draw() {
+    draw() {
         const currElement = Number(this.seq.getElement(this.currentIndex++));
-		const angle = this.rotMap[currElement];
+        const angle = this.rotMap[currElement];
 
-		if (angle == undefined) this.sketch.noLoop();
+        if (angle == undefined) this.sketch.noLoop();
 
         const oldX = this.X;
         const oldY = this.Y;
@@ -144,7 +144,7 @@ class VisualizerTurtle extends VisualizerDefault implements VisualizerInterface 
 
         this.sketch.line(oldX,oldY,this.X,this.Y);
         if (this.currentIndex > this.seq.last) this.sketch.noLoop();
-	}
+    }
 }
 
 


### PR DESCRIPTION
[EDIT: This is now the agreed-upon resolution of #42, so this IS NOW advanced for review. Thanks!]

  To support this, SequenceInterface now has properties first and last
   giving the smallest and largest valid indices (with last allowed to
   be infinity). That way, it never has to return undefined.
    
   Resolves #42.
   Resolves #19.

[Everything below here is now obsolete.]
 NOTE: this is presented as a reference implementation for comparison with #50 of the alternate plan for dealing with Sequence return types and computing with Sequence values, as in the discussion for issue #48. Please see that discussion and comment.

 This had not been suggested for review until further commentary/consensus has been reached in #48 as to which direction to go at this point. I just thought it might be helpful to see how each of the plans turned out. A consensus has now been reached, and just this ONE PR (not #50) is now proposed for review. Thanks!