### PR TITLE
chore: Rename Title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "newnumberscope",
+  "name": "frontscope",
   "version": "0.2.0",
   "private": true,
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,11 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>Numberscope</title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but Numberscope doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->


### PR DESCRIPTION
We rename the title from "newnumberscope" to "Numberscope". The old
title was obtained from the "name" field in `package.json`. I'm not a
fan of this method since the "name" field in `package.json` is supposed
to be lowercase. Thus, we change the "name" in `package.json` to be
"frontscope" to match the repo's name.

Related to https://github.com/numberscope/frontscope/pull/88 in that
it's a minor cosmetic thing that will make the frontend look a bit
nicer.

Here's how the title should look now:
![new-title](https://user-images.githubusercontent.com/60749003/148613925-333f879b-642d-40a1-b6c3-b2fce77c836b.png)