### PR TITLE
fix: Make Footer Reappear, Make Footer Dynamic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "newnumberscope",
+  "name": "frontscope",
   "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "newnumberscope",
+      "name": "frontscope",
       "version": "0.2.0",
       "dependencies": {
         "axios": "^0.21.2",

--- a/src/views/minor/Footer.vue
+++ b/src/views/minor/Footer.vue
@@ -1,22 +1,29 @@
 <template>
-    <footer class="page-footer font-small" style="backgroundcolor: #3333ff">
+    <footer class="page-footer font-small">
         <div class="footer-copyright text-center py-3" style="color: white">
-            © 2020 Copyright:
-            <a style="color: white" href="https://colorado.edu">
-                colorado.edu
-            </a>
+            {{ copyright }}
         </div>
     </footer>
 </template>
 
 <script>
+    const currentYear = new Date().getFullYear()
+    const copyrightText
+        = `Copyright © 2020-${currentYear} University of Colorado Boulder`
     export default {
+        /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+        data() {
+            return {
+                copyright: copyrightText
+            }
+        },
         name: 'FooterComponent',
     }
 </script>
 
 <style>
     footer {
+        background-color: #3333ff;
         position: absolute;
         bottom: 0;
         width: 100%;

--- a/tests/unit/Footer.spec.ts
+++ b/tests/unit/Footer.spec.ts
@@ -1,0 +1,10 @@
+import {mount} from '@vue/test-utils'
+import Footer from '@/views/minor/Footer.vue'
+
+test('copyright statement should be correct and up-to-date', () => {
+    const wrapper = mount(Footer)
+    const currentYear = new Date().getFullYear()
+    expect(wrapper.text()).toContain(
+        `Copyright © 2020-${currentYear} University of Colorado Boulder`
+    )
+})


### PR DESCRIPTION
https://github.com/numberscope/frontscope/pull/101 made the footer
disappear. In this commit, we make it reappear. We also make it dynamic
so that it doesn't become outdated. We also add a test for the footer.

I tried to add this commit in
https://github.com/numberscope/frontscope/pull/101, but I must have
merged it incorrectly.