### PR TITLE
Add License, Copyright, and Info to Footer

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,18 @@
+Copyright 2020-2022 Regents of University of Colorado
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/views/minor/Footer.vue
+++ b/src/views/minor/Footer.vue
@@ -1,20 +1,33 @@
 <template>
     <footer class="page-footer font-small">
-        <div class="footer-copyright text-center py-3" style="color: white">
+        <div class="text-center py-3" style="color: white">
             {{ copyright }}
+            <p>
+                Licensed under the
+                <a
+                    class="footer-link"
+                    href="https://opensource.org/licenses/MIT">
+                    MIT License</a
+                >.
+            </p>
+            <p>
+                By using this website, you agree any images you create are
+                released into the public domain.
+            </p>
         </div>
     </footer>
 </template>
 
 <script>
     const currentYear = new Date().getFullYear()
+    // prettier-ignore
     const copyrightText
-        = `Copyright © 2020-${currentYear} University of Colorado Boulder`
+    = `Copyright © 2020-${currentYear} Regents of University of Colorado`
     export default {
         /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
         data() {
             return {
-                copyright: copyrightText
+                copyright: copyrightText,
             }
         },
         name: 'FooterComponent',
@@ -27,6 +40,11 @@
         position: absolute;
         bottom: 0;
         width: 100%;
-        height: 100px;
+    }
+    .footer-link {
+        color: orange;
+    }
+    .footer-link:hover {
+        color: white;
     }
 </style>


### PR DESCRIPTION
This PR adds a LICENSE.md, correct copyright info to the footer, and a message in the footer about images being released into the public domain.