### PR TITLE
chore: Adjust vue components to type correctly

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,5 +18,7 @@ module.exports = {
             {overrides: {'=': 'after'}},
         ],
         'vue/multi-word-component-names': 'off',
+        // For the Paramable interface, v-model directives need type annotation
+        'vue/valid-v-model': 'off',
     },
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,5 @@
 npm run lint:list || echo 'Files listed above will be reformatted and staged.'
 npm run lint:staged
 npm run lint:check
+npm run typecheck
 npm run test:unit

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "frontscope",
     "version": "0.3.0",
     "scripts": {
-        "dev": "vite",
-        "build": "vue-tsc --noEmit && vite build",
+        "dev": "npm run typecheck && vite",
+        "build": "npm run typecheck && vite build",
         "preview": "vite preview --port 5050",
         "test:unit": "vitest run",
         "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",

--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -25,18 +25,13 @@
 </template>
 
 <script lang="ts">
+    import {defineComponent} from 'vue'
     import p5 from 'p5'
     // we need a unique id for each canvas
     // see https://github.com/vuejs/vue/issues/5886#issuecomment-308647738
-    let cid = 0
-    export default {
+    let cid_count = 0
+    export default defineComponent({
         name: 'BundleCard',
-        // we need a unique id for each canvas
-        // see https://github.com/vuejs/vue/issues/5886#issuecomment-308647738
-        beforeCreate() {
-            this.cid = cid.toString()
-            cid += 1
-        },
         mounted() {
             const seq = this.seq
             seq.initialize()
@@ -61,10 +56,18 @@
         },
         methods: {},
         props: {
-            seq: Object,
-            viz: Object,
+            seq: {type: Object, required: true},
+            viz: {type: Object, required: true},
+            // we need a unique id for each canvas
+            // see https://github.com/vuejs/vue/issues/5886
+            cid: {
+                type: String,
+                default: function () {
+                    return 'Card-' + cid_count++
+                },
+            },
         },
-    }
+    })
 </script>
 
 <style scoped>

--- a/src/components/BundleManager.vue
+++ b/src/components/BundleManager.vue
@@ -68,11 +68,11 @@
         },
         props: {
             activeSeq: {
-                type: Object as PropType<SequenceInterface | null>,
+                type: [null, Object] as PropType<SequenceInterface | null>,
                 required: true,
             },
             activeViz: {
-                type: Object as PropType<VisualizerInterface | null>,
+                type: [null, Object] as PropType<VisualizerInterface | null>,
                 required: true,
             },
             bundles: Array as PropType<

--- a/src/components/BundleManager.vue
+++ b/src/components/BundleManager.vue
@@ -40,7 +40,7 @@
         <div class="row">
             <BundleCard
                 v-for="bundle in bundles"
-                v-bind:key="bundle.uid"
+                v-bind:key="bundle.seq.name + bundle.viz.name"
                 v-bind:seq="bundle.seq"
                 v-bind:viz="bundle.viz"
                 v-on:drawBundle="$emit('drawBundle', $event)" />
@@ -57,15 +57,30 @@
 </template>
 
 <script lang="ts">
+    import {defineComponent} from 'vue'
+    import type {PropType} from 'vue'
+    import type {VisualizerInterface} from '../visualizers/VisualizerInterface'
+    import type {SequenceInterface} from '../sequences/SequenceInterface'
     import BundleCard from './BundleCard.vue'
-    export default {
+    export default defineComponent({
         components: {
             BundleCard,
         },
         props: {
-            activeSeq: Object,
-            activeViz: Object,
-            bundles: Array,
+            activeSeq: {
+                type: Object as PropType<SequenceInterface | null>,
+                required: true,
+            },
+            activeViz: {
+                type: Object as PropType<VisualizerInterface | null>,
+                required: true,
+            },
+            bundles: Array as PropType<
+                {
+                    seq: SequenceInterface
+                    viz: VisualizerInterface
+                }[]
+            >,
         },
         computed: {
             readyToBundle: function (): boolean {
@@ -77,5 +92,5 @@
                 )
             },
         },
-    }
+    })
 </script>

--- a/src/components/CanvasArea.vue
+++ b/src/components/CanvasArea.vue
@@ -12,16 +12,26 @@
 </template>
 
 <script lang="ts">
+    import {defineComponent} from 'vue'
+    import type {PropType} from 'vue'
+    import type {VisualizerInterface} from '../visualizers/VisualizerInterface'
+    import type {SequenceInterface} from '../sequences/SequenceInterface'
     import p5 from 'p5'
     import StopDrawingButton from './StopDrawingButton.vue'
-    export default {
+    export default defineComponent({
         name: 'CanvasArea',
         components: {
             StopDrawingButton,
         },
         props: {
-            activeSeq: Object,
-            activeViz: Object,
+            activeSeq: {
+                type: Object as PropType<SequenceInterface>,
+                required: true,
+            },
+            activeViz: {
+                type: Object as PropType<VisualizerInterface>,
+                required: true,
+            },
         },
         methods: {
             closeCanvas: function (): void {
@@ -30,9 +40,6 @@
             },
         },
         mounted: function (): void {
-            console.log('Drawing with Visualizer: ', this.activeViz.name)
-            console.log('Drawing with Sequence', this.activeSeq.name)
-            // params here are ID and finite
             const activeSeq = this.activeSeq
             activeSeq.initialize()
             const activeViz = this.activeViz
@@ -53,7 +60,7 @@
         data: function () {
             return {drawing: {} as p5} // To get correct type
         },
-    }
+    })
 </script>
 
 <style scoped></style>

--- a/src/components/SeqGetter.vue
+++ b/src/components/SeqGetter.vue
@@ -5,13 +5,14 @@
 </template>
 
 <script lang="ts">
-    export default {
+    import {defineComponent} from 'vue'
+    export default defineComponent({
         name: 'SeqGetter',
         props: {
             title: String,
             instanceId: String,
         },
-    }
+    })
 </script>
 
 <style scoped>

--- a/src/components/SeqSelector.vue
+++ b/src/components/SeqSelector.vue
@@ -12,13 +12,14 @@
 </template>
 
 <script lang="ts">
-    export default {
+    import {defineComponent} from 'vue'
+    export default defineComponent({
         name: 'SeqSelector',
         props: {
             title: String,
             isInstance: Boolean,
         },
-    }
+    })
 </script>
 
 <style scoped>

--- a/src/components/SequenceMenu.vue
+++ b/src/components/SequenceMenu.vue
@@ -6,14 +6,14 @@
                 v-for="seq in isGetter(sequences, false)"
                 v-bind:title="seq.name"
                 v-bind:isInstance="seq.kind == instanceKind"
-                v-bind:key="seq.id"
+                v-bind:key="seq.name"
                 v-on:set-seq-params="setParams(seq)"
                 v-on:stage-instance="createSeq(true, seq)" />
             <hr />
             <SeqGetter
                 v-for="seq in isGetter(sequences, true)"
                 v-bind:title="seq.name"
-                v-bind:key="seq.id"
+                v-bind:key="seq.name"
                 v-on:load-seq="loadSeq(seq)" />
         </ul>
         <SeqVizParamsModal
@@ -28,22 +28,29 @@
 </template>
 
 <script lang="ts">
+    import {defineComponent} from 'vue'
+    import type {PropType} from 'vue'
     import SeqSelector from './SeqSelector.vue'
     import SeqGetter from './SeqGetter.vue'
     import SeqVizParamsModal from './SeqVizParamsModal.vue'
-    import {
+    import type {
         SequenceInterface,
         SequenceConstructor,
+    } from '../sequences/SequenceInterface'
+    import {
         SequenceExportModule,
         SequenceExportKind,
-    } from '../sequences/SequenceInterface.ts'
-    import {SequenceClassDefault} from '../sequences/SequenceClassDefault.ts'
-    export default {
+    } from '../sequences/SequenceInterface'
+    import {SequenceClassDefault} from '../sequences/SequenceClassDefault'
+    export default defineComponent({
         name: 'SequenceMenu',
         props: {
-            sequences: Array,
+            sequences: {
+                type: Array as PropType<SequenceExportModule[]>,
+                required: true,
+            },
             activeViz: Object,
-            activeSeq: Object,
+            activeSeq: Object as PropType<SequenceInterface | null>,
         },
         components: {
             SeqSelector,
@@ -127,7 +134,7 @@
                 errors: [] as string[],
             }
         },
-    }
+    })
 </script>
 
 <style scoped>

--- a/src/components/StopDrawingButton.vue
+++ b/src/components/StopDrawingButton.vue
@@ -11,11 +11,12 @@
 </template>
 
 <script lang="ts">
-    export default {
+    import {defineComponent} from 'vue'
+    export default defineComponent({
         props: {
             buttonText: String,
         },
-    }
+    })
 </script>
 
 <style scoped>

--- a/src/components/ToolSelector.vue
+++ b/src/components/ToolSelector.vue
@@ -5,12 +5,13 @@
 </template>
 
 <script lang="ts">
-    export default {
+    import {defineComponent} from 'vue'
+    export default defineComponent({
         name: 'VizSelector',
         props: {
             title: String,
         },
-    }
+    })
 </script>
 
 <style scoped>

--- a/src/components/VisualizationMenu.vue
+++ b/src/components/VisualizationMenu.vue
@@ -5,7 +5,7 @@
             <VizSelector
                 v-for="viz in visualizers"
                 v-bind:title="viz.name"
-                v-bind:key="viz.id"
+                v-bind:key="viz.name"
                 v-on:set-viz-params="setParams(viz)" />
         </ul>
         <SeqVizParamsModal
@@ -18,17 +18,19 @@
 </template>
 
 <script lang="ts">
-    import {
+    import {defineComponent} from 'vue'
+    import type {PropType} from 'vue'
+    import type {
         VisualizerInterface,
         VisualizerExportModule,
     } from '@/visualizers/VisualizerInterface'
     import VizSelector from '../components/ToolSelector.vue'
     import SeqVizParamsModal from '../components/SeqVizParamsModal.vue'
-    export default {
+    export default defineComponent({
         name: 'VizualizationMenu',
         props: {
-            visualizers: Array,
-            activeViz: Object,
+            visualizers: Array as PropType<VisualizerExportModule[]>,
+            activeViz: Object as PropType<VisualizerInterface | null>,
             activeSeq: Object,
         },
         components: {
@@ -65,7 +67,7 @@
                 errors: [] as string[],
             }
         },
-    }
+    })
 </script>
 
 <style scoped>

--- a/src/components/__tests__/SeqSelector.spec.ts
+++ b/src/components/__tests__/SeqSelector.spec.ts
@@ -27,6 +27,7 @@ describe('SeqGetter', () => {
         const wrapper = mount(SeqSelector, {
             props: {
                 title: 'Foo Title',
+                isInstance: false,
             },
         })
         expect(wrapper.text()).toContain('Foo Title')

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -1,4 +1,4 @@
-import {ValidationStatus} from '../shared/ValidationStatus'
+import type {ValidationStatus} from '../shared/ValidationStatus'
 import {SequenceExportModule, SequenceExportKind} from './SequenceInterface'
 import {SequenceCached} from './SequenceCached'
 

--- a/src/sequences/SequenceFormula.ts
+++ b/src/sequences/SequenceFormula.ts
@@ -41,12 +41,12 @@ class SequenceFormula extends SequenceCached {
         let parsetree = undefined
         try {
             parsetree = math.parse(this.params.formula.value)
-        } catch (err) {
+        } catch (err: unknown) {
             status.isValid = false
             status.errors.push(
                 'Could not parse formula: ' + this.params.formula.value
             )
-            status.errors.push(err.message)
+            status.errors.push((err as Error).message)
             return status
         }
         const othersymbs = parsetree.filter(

--- a/src/shared/Paramable.ts
+++ b/src/shared/Paramable.ts
@@ -73,6 +73,7 @@ export interface ParamInterface {
 export interface ParamableInterface {
     name: string
     description: string
+    isValid: boolean
     /**
      * params determines the parameters that will be settable via the
      * user interface. Each key should match a top-level property name of the
@@ -119,11 +120,8 @@ export class Paramable implements ParamableInterface {
     name = 'Paramable'
     description = 'A class which can have parameters set'
     params: {[key: string]: ParamInterface} = {}
-    isValid: boolean
+    isValid = false
 
-    constructor() {
-        this.isValid = false
-    }
     /**
      * All implementations based on this default delegate the checking of
      * parameters to the checkParameters() method.

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -35,11 +35,13 @@
 </template>
 
 <script lang="ts">
+    import {defineComponent} from 'vue'
     import {RouterLink} from 'vue-router'
     // To be honest: this check exists only to avoid "unused variable" warning
     if (!RouterLink) {
         console.log('Failed import of RouterLink')
     }
+    export default defineComponent({})
 </script>
 
 <style>

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -29,11 +29,13 @@
 </template>
 
 <script lang="ts">
+    import {defineComponent} from 'vue'
     import {RouterLink} from 'vue-router'
     // To be honest: this check exists only to avoid "unused variable" warning
     if (!RouterLink) {
         console.log('Failed import of RouterLink')
     }
+    export default defineComponent({})
 </script>
 
 <style>

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -3,8 +3,8 @@
         <div class="row" v-if="drawingActive">
             <div class="col-sm-12">
                 <CanvasArea
-                    v-bind:activeViz="activeViz"
-                    v-bind:activeSeq="activeSeq"
+                    v-bind:activeViz="guaranteeViz()"
+                    v-bind:activeSeq="guaranteeSeq()"
                     v-on:closeCanvas="closeCanvas()" />
             </div>
         </div>
@@ -33,19 +33,20 @@
 </template>
 
 <script lang="ts">
+    import {defineComponent} from 'vue'
     import VisualizationMenu from '../components/VisualizationMenu.vue'
     import SequenceMenu from '../components/SequenceMenu.vue'
     import CanvasArea from '../components/CanvasArea.vue'
     import BundleManager from '../components/BundleManager.vue'
     import VISUALIZERS from '../visualizers/visualizers'
     import SEQUENCES from '../sequences/sequences'
+    import type {SequenceInterface} from '../sequences/SequenceInterface'
     import {
-        SequenceInterface,
-        SequenceExportModule,
         SequenceExportKind,
+        SequenceExportModule,
     } from '../sequences/SequenceInterface'
-    import {VisualizerInterface} from '../visualizers/VisualizerInterface'
-    export default {
+    import type {VisualizerInterface} from '../visualizers/VisualizerInterface'
+    export default defineComponent({
         name: 'ToolMain',
         components: {
             VisualizationMenu,
@@ -54,8 +55,14 @@
             BundleManager,
         },
         methods: {
+            guaranteeViz: function () {
+                return this.activeViz as VisualizerInterface
+            },
             setActiveViz: function (newViz: VisualizerInterface) {
                 this.activeViz = newViz
+            },
+            guaranteeSeq: function () {
+                return this.activeSeq as SequenceInterface
             },
             setActiveSeq: function (newSeq: SequenceInterface) {
                 this.activeSeq = newSeq
@@ -71,8 +78,8 @@
             },
             bundleSeqVizPair: function () {
                 const bundle = {
-                    seq: this.activeSeq,
-                    viz: this.activeViz,
+                    seq: this.activeSeq as SequenceInterface,
+                    viz: this.activeViz as VisualizerInterface,
                 }
                 this.seqVizPairs.push(bundle)
                 this.clearActive()
@@ -108,14 +115,14 @@
                 visualizers: visualizers,
                 sequences: sequences,
                 seqVizPairs: [] as {
-                    seq: SequenceInterface | null // Get the type correct
-                    viz: VisualizerInterface | null
+                    seq: SequenceInterface
+                    viz: VisualizerInterface
                 }[],
-                activeViz: null as VisualizerInterface | null, // ditto
-                activeSeq: null as SequenceInterface | null, // ditto
+                activeViz: null as VisualizerInterface | null,
+                activeSeq: null as SequenceInterface | null,
                 drawingActive: false,
             }
             return state
         },
-    }
+    })
 </script>

--- a/src/views/UserManual.vue
+++ b/src/views/UserManual.vue
@@ -63,7 +63,8 @@
 
 <script lang="ts">
     import background200px from '../assets/img/homepage/background200px.jpg'
-    export default {
+    import {defineComponent} from 'vue'
+    export default defineComponent({
         name: 'UserManual',
         data() {
             return {
@@ -168,7 +169,7 @@
                 }
             },
         },
-    }
+    })
 </script>
 
 <style>

--- a/src/visualizers/VisualizerChaos.ts
+++ b/src/visualizers/VisualizerChaos.ts
@@ -355,7 +355,7 @@ class VisualizerChaos extends VisualizerDefault {
         this.sketch.frameRate(10)
 
         // canvas clear/background
-        this.sketch.clear()
+        this.sketch.clear(0, 0, 0, 0)
         this.sketch.background(this.currentPalette.backgroundColor)
 
         // Draw corner labels if desired

--- a/src/visualizers/VisualizerShiftCompare.ts
+++ b/src/visualizers/VisualizerShiftCompare.ts
@@ -10,7 +10,7 @@ class VizShiftCompare
     implements VisualizerInterface
 {
     name = 'Shift Compare'
-    private img: p5.Image = new p5.Image()
+    private img: p5.Image = new p5.Image(1, 1) // just a dummy
     mod = 2n
     params = {
         mod: {


### PR DESCRIPTION
  This PR modifies the node `dev` and `build` scripts and the pre-commit
  actions to typecheck all code in Vue components. Correspondingly, it
  adjusts all of the components to pass TypeScript type checking. In particular,
  this means boilerplate of a call to Vue.defineComponent() in every component
  and view (per Vue 3 documentation; otherwise TypeScript cannot infer the
  proper types).

  The most significant resulting change was to the mechanism of generating
  unique canvas ids in BundleCard, as the previous mechanism did not allow
  defineComponent() to infer the type of the `cid` member. This commit
  therefore switches to a later proposed mechanism in the same Vue GitHub issue
  referenced by the comment on the previous mechanism.

  One other change worth mentioning is that in several places data properties
  called "id" or "uid" were being used as `v-bind:key` values, from objects
  that had no such properties. These have all been changed to use "name"
  properties, which do exist. That leads to the question of whether there will
  be a problem if two Sequences (say) have the same "name". It seems unlikely,
  since presumably before this change, the "id" properties were all undefined
  and hence identical.

  Otherwise, the changes were essentially all type annotation. Note that there
  was a great deal of new annotation in SeqVizParamsModal as the Paramable
  interface is currently based on a (probably not particularly
  TypeScript-conformant) scheme of string properties determining what type
  an "unknown" value should be cast to. In particular, some of this typecasting
  unfortunately as far as I could figure out has to happen in `v-model`
  directives, forcing me to turn off the `vue/valid-v-model` eslint rule (as
  `value as boolean`, for example, does not qualify as an l-value in eslint's
  judgment).

  Resolves #131.