### PR TITLE
fix: ignore `.gitignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 *.ico
 *~
 .husky
+.gitignore
 .prettierignore
 .vscode
 node_modules

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
         "vue-unique-id": "^3.2.1"
     },
     "lint-staged": {
-        "*": "prettier-eslint --write"
+        "*": "prettier-eslint --write --ignore .prettierignore"
     }
 }


### PR DESCRIPTION
Modify the lint-staged script so that it uses the `.prettierignore` file
to ignore `.gitignore`.

Resolves https://github.com/numberscope/frontscope/issues/137.