### PR TITLE
UI tweaks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
 
 <style>
     main {
-        min-height: 100vh;
+        min-height: 80vh;
         font-family: Arial, Helvetica, sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,21 +14,25 @@
 
 <style>
     :root {
-        --ns-light-blue: #809fff;
-        --ns-dark-blue: #3333ff;
+        --ns-foreground: #2c3e50;
+        --ns-navigation-foreground: white;
+        --ns-navigation-background: #809fff;
+        --ns-information-foreground: white;
+        --ns-information-background: #3333ff;
+        --ns-footer-height: 9ex;
     }
     main {
-        min-height: 80vh;
+        min-height: calc(100vh - var(--ns-footer-height));
         font-family: Arial, Helvetica, sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-        color: #2c3e50;
+        color: var(--ns-foreground);
     }
     nav {
         padding: 30px;
     }
     nav a {
         font-weight: bold;
-        color: #2c3e50;
+        color: var(--ns-foreground);
     }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,10 @@
 </script>
 
 <style>
+    :root {
+        --ns-light-blue: #809fff;
+        --ns-dark-blue: #3333ff;
+    }
     main {
         min-height: 80vh;
         font-family: Arial, Helvetica, sans-serif;

--- a/src/components/BundleManager.vue
+++ b/src/components/BundleManager.vue
@@ -14,7 +14,7 @@
                     class="alert alert-warning">
                     Select a sequence
                 </div>
-                <div v-else class="alert alert-primary">
+                <div v-else class="alert ready">
                     Active sequence: {{ activeSeq.name }}
                 </div>
             </div>
@@ -26,14 +26,14 @@
                     class="alert alert-warning">
                     Select a visualizer
                 </div>
-                <div v-else class="alert alert-primary">
+                <div v-else class="alert ready">
                     Active visualizer: {{ activeViz.name }}
                 </div>
             </div>
         </div>
         <button
             v-if="readyToBundle"
-            class="btn btn-primary"
+            class="btn nsnav"
             v-on:click="$emit('createBundle')">
             Create Bundle
         </button>
@@ -94,3 +94,17 @@
         },
     })
 </script>
+
+<style scoped>
+    .ready {
+        color: var(--ns-information-foreground);
+        background-color: var(--ns-information-background);
+    }
+    .nsnav {
+        border-color: var(--ns-information-background);
+    }
+    .nsnav:hover {
+        color: var(--ns-navigation-foreground);
+        background-color: var(--ns-navigation-background);
+    }
+</style>

--- a/src/components/SeqGetter.vue
+++ b/src/components/SeqGetter.vue
@@ -20,7 +20,7 @@
         cursor: pointer;
     }
     li:hover {
-        background-color: #809fff;
+        background-color: var(--ns-light-blue);
         color: #ffffff;
     }
     li {

--- a/src/components/SeqGetter.vue
+++ b/src/components/SeqGetter.vue
@@ -20,8 +20,8 @@
         cursor: pointer;
     }
     li:hover {
-        background-color: var(--ns-light-blue);
-        color: #ffffff;
+        color: var(--ns-navigation-foreground);
+        background-color: var(--ns-navigation-background);
     }
     li {
         text-align: left;

--- a/src/components/SeqSelector.vue
+++ b/src/components/SeqSelector.vue
@@ -27,7 +27,7 @@
         cursor: pointer;
     }
     li:hover {
-        background-color: #809fff;
+        background-color: var(--ns-light-blue);
         color: #ffffff;
     }
     li {

--- a/src/components/SeqSelector.vue
+++ b/src/components/SeqSelector.vue
@@ -1,12 +1,12 @@
 <template>
     <div v-if="!isInstance">
         <a v-on:click="$emit('set-seq-params')">
-            <li class="list-group-item">{{ title }}</li>
+            <li class="btn">{{ title }}</li>
         </a>
     </div>
     <div v-else>
         <a v-on:click="$emit('stage-instance')">
-            <li class="list-group-item">Custom: {{ title }}</li>
+            <li class="btn">Custom: {{ title }}</li>
         </a>
     </div>
 </template>
@@ -27,10 +27,12 @@
         cursor: pointer;
     }
     li:hover {
-        background-color: var(--ns-light-blue);
-        color: #ffffff;
+        color: var(--ns-navigation-foreground);
+        background-color: var(--ns-navigation-background);
     }
     li {
+        width: 100%;
         text-align: left;
+        border-color: var(--ns-information-background);
     }
 </style>

--- a/src/components/ToolSelector.vue
+++ b/src/components/ToolSelector.vue
@@ -1,6 +1,6 @@
 <template>
     <a v-on:click="$emit('set-viz-params', title)">
-        <li class="list-group-item">{{ title }}</li>
+        <li class="btn">{{ title }}</li>
     </a>
 </template>
 
@@ -19,10 +19,12 @@
         cursor: pointer;
     }
     li:hover {
-        background-color: var(--ns-light-blue);
-        color: #ffffff;
+        color: var(--ns-navigation-foreground);
+        background-color: var(--ns-navigation-background);
     }
     li {
         text-align: left;
+        width: 100%;
+        border-color: var(--ns-information-background);
     }
 </style>

--- a/src/components/ToolSelector.vue
+++ b/src/components/ToolSelector.vue
@@ -19,7 +19,7 @@
         cursor: pointer;
     }
     li:hover {
-        background-color: #809fff;
+        background-color: var(--ns-light-blue);
         color: #ffffff;
     }
     li {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,63 +17,12 @@
                 >CC0 1.0</a
             >.
         </p>
-        <div>
-            <div class="row" id="visualizerInfo">
-                <div class="col">
-                    <img class="visualizerImg" :src="gameOfLife" />
-                    <h2 class="mt-4 visualizerTitle"><b>Game of Life</b></h2>
-                    <p class="orangeText">
-                        The Game of Life is a cellular automaton model. The
-                        playing field for Game of Life is a grid of cells.
-                        Each cell can be either alive or dead and has eight
-                        neighbors, those being the cells directly touching it
-                        horizontally, vertically, and diagonally. Certain
-                        rules dictate whether or not a given cell will be
-                        alive in the next generation.
-                    </p>
-                </div>
-                <div class="col">
-                    <img class="visualizerImg" :src="shiftCompare" />
-                    <h2 class="mt-4 visualizerTitle">
-                        <b>Shift Comparison</b>
-                    </h2>
-                    <p class="orangeText">
-                        The shift comparison picture of a<sub>n</sub> is
-                        formed by setting the pixel at position (x,y) to be
-                        white if a<sub>x</sub>=a<sub>x+y</sub>, and black
-                        otherwise. The picture captures how a<sub>n</sub>
-                        repeats. Many interesting sequences do not repeat, but
-                        by taking the sequence mod n, that is, taking the
-                        remainders after dividing by n, we get sequences that
-                        do repeat.
-                    </p>
-                </div>
-                <div class="col">
-                    <img class="visualizerImg" :src="turtle" />
-                    <h2 class="mt-4 visualizerTitle">
-                        <b>Turtle Graphics</b>
-                    </h2>
-                    <p class="orangeText">
-                        Imagine a small turtle sitting on a paper. It can move
-                        forward and rotate, and as it moves it leaves a trail
-                        of ink behind it. The visualization of integer
-                        sequences with turtle graphics can thus be constructed
-                        with parameters from the numbers of given sequences.
-                        Most integer sequences will produce mindless
-                        scribbling. Some produce surprising geometric figures.
-                    </p>
-                </div>
-            </div>
-        </div>
     </div>
 </template>
 
 <script setup lang="ts">
     import {RouterLink} from 'vue-router'
     import background4 from '../assets/img/toolpage/background4.jpg'
-    import gameOfLife from '../assets/img/homepage/gof.png'
-    import shiftCompare from '../assets/img/homepage/sc.png'
-    import turtle from '../assets/img/homepage/turtle.png'
 </script>
 
 <style>
@@ -97,15 +46,6 @@
         margin-bottom: 2em;
         font-weight: bold;
         font-size: large;
-    }
-    #visualizerInfo {
-        background-color: #809fff;
-        color: white;
-        margin-top: 2em;
-        padding: 4em;
-    }
-    .visualizerImg {
-        width: 70%;
     }
     @media only screen and (max-width: 600px) {
         #background4 {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -89,6 +89,9 @@
     #goToScopeButton {
         background-color: #3333ff;
     }
+    #goToScopeButton:hover {
+        text-decoration: underline;
+    }
     #numberscopeDescription {
         margin-top: 2em;
         margin-bottom: 2em;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -36,7 +36,7 @@
         max-width: 50%;
     }
     #goToScopeButton {
-        background-color: #3333ff;
+        background-color: var(--ns-dark-blue);
         margin-bottom: 1ex;
     }
     #goToScopeButton:hover {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -6,7 +6,7 @@
         <p id="numberscopeDescription">
             The Online Tool for Visualizing Integer Sequences
         </p>
-        <RouterLink class="btn btn-primary" to="/scope">
+        <RouterLink id="goToScopeButton" class="btn btn-primary" to="/scope">
             Go to the 'Scope
         </RouterLink>
         <p class="mt-4">
@@ -85,6 +85,9 @@
         border: solid black;
         border-radius: 10%;
         max-width: 50%;
+    }
+    #goToScopeButton {
+        background-color: #3333ff;
     }
     #numberscopeDescription {
         margin-top: 2em;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,8 @@
 <template>
     <div id="homeContent">
-        <img :src="background4" id="background4" />
+        <RouterLink to="/scope">
+            <img :src="background4" id="background4" />
+        </RouterLink>
         <p id="numberscopeDescription">
             The Online Tool for Visualizing Integer Sequences
         </p>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -6,7 +6,7 @@
         <p id="numberscopeDescription">
             The Online Tool for Visualizing Integer Sequences
         </p>
-        <RouterLink id="goToScopeButton" class="btn btn-primary" to="/scope">
+        <RouterLink id="goToScopeButton" class="btn" to="/scope">
             Go to the 'Scope
         </RouterLink>
         <p>
@@ -36,11 +36,12 @@
         max-width: 50%;
     }
     #goToScopeButton {
-        background-color: var(--ns-dark-blue);
         margin-bottom: 1ex;
+        border-color: var(--ns-information-background);
     }
     #goToScopeButton:hover {
-        text-decoration: underline;
+        color: var(--ns-navigation-foreground);
+        background-color: var(--ns-navigation-background);
     }
     #numberscopeDescription {
         margin-top: 1.5ex;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,7 +9,7 @@
         <RouterLink id="goToScopeButton" class="btn btn-primary" to="/scope">
             Go to the 'Scope
         </RouterLink>
-        <p class="mt-4">
+        <p>
             By using this website, you agree that any images or media you
             create using the tools on this website are released by you into
             the public domain according to
@@ -37,13 +37,14 @@
     }
     #goToScopeButton {
         background-color: #3333ff;
+        margin-bottom: 1ex;
     }
     #goToScopeButton:hover {
         text-decoration: underline;
     }
     #numberscopeDescription {
-        margin-top: 2em;
-        margin-bottom: 2em;
+        margin-top: 1.5ex;
+        margin-bottom: 1.5ex;
         font-weight: bold;
         font-size: large;
     }

--- a/src/views/minor/Footer.vue
+++ b/src/views/minor/Footer.vue
@@ -23,11 +23,10 @@
 
 <style>
     footer {
-        background-color: var(--ns-dark-blue);
-        color: white;
+        color: var(--ns-information-foreground);
+        background-color: var(--ns-information-background);
+        height: var(--ns-footer-height);
         padding-top: 10px;
-        position: fixed;
-        bottom: 0;
         width: 100%;
     }
     footer p {

--- a/src/views/minor/Footer.vue
+++ b/src/views/minor/Footer.vue
@@ -3,8 +3,8 @@
         <p>
             Thank you very much to
             <a href="/doc/doc/acknowledgments/index.html" class="footer-link">
-                those who made Numberscope possible
-            </a>
+                those who made Numberscope possible</a
+            >
             over the years!
         </p>
     </footer>

--- a/src/views/minor/Footer.vue
+++ b/src/views/minor/Footer.vue
@@ -7,6 +7,17 @@
             >
             over the years!
         </p>
+        <p>
+            <i class="bi bi-github"></i>&nbsp;
+            <a class="footer-link" href="https://github.com/numberscope"
+                >GitHub</a
+            >
+            <span id="linkSpacer"></span>
+            <i class="bi bi-twitter"></i>&nbsp;
+            <a class="footer-link" href="https://twitter.com/numberscoper"
+                >Twitter</a
+            >
+        </p>
     </footer>
 </template>
 
@@ -21,5 +32,8 @@
     }
     .footer-link:hover {
         color: white;
+    }
+    #linkSpacer {
+        padding: 0 2em;
     }
 </style>

--- a/src/views/minor/Footer.vue
+++ b/src/views/minor/Footer.vue
@@ -25,7 +25,13 @@
     footer {
         background-color: var(--ns-dark-blue);
         color: white;
-        padding: 16px 4px;
+        padding-top: 10px;
+        position: fixed;
+        bottom: 0;
+        width: 100%;
+    }
+    footer p {
+        margin-bottom: 0.5rem;
     }
     .footer-link {
         color: orange;

--- a/src/views/minor/Footer.vue
+++ b/src/views/minor/Footer.vue
@@ -23,7 +23,7 @@
 
 <style>
     footer {
-        background-color: #3333ff;
+        background-color: var(--ns-dark-blue);
         color: white;
         padding: 16px 4px;
     }

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -38,12 +38,13 @@
                         <li class="nav-item">
                             <a
                                 href="/doc/doc/about/index.html"
-                                class="nav-link">
+                                class="nav-link"
+                                id="aboutLink">
                                 About
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a href="/doc/" class="nav-link">
+                            <a href="/doc/" class="nav-link" id="docLink">
                                 Documentation
                             </a>
                         </li>
@@ -85,7 +86,7 @@
     */
     #scopeLink,
     #aboutLink,
-    #helpLink {
+    #docLink {
         color: white;
     }
     .navbar-text a {
@@ -93,7 +94,7 @@
     }
     #scopeLink:hover,
     #aboutLink:hover,
-    #helpLink:hover {
+    #docLink:hover {
         text-decoration: underline;
     }
     .navbar-text a:hover {

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -77,10 +77,10 @@
 
 <style>
     .navbar-nav li.nav-item .nav-link {
-        color: white;
+        color: var(--ns-navigation-foreground);
     }
     .navbar-nav li.nav-item .nav-link:hover {
-        color: white;
+        color: var(--ns-navigation-foreground);
     }
     .navbar-text a {
         text-decoration: none;
@@ -96,8 +96,8 @@
         font-size: small;
     }
     .navbar-custom {
-        background-color: var(--ns-light-blue);
-        color: white;
+        color: var(--ns-navigation-foreground);
+        background-color: var(--ns-navigation-background);
     }
     #logoWithMicroscope {
         width: 10em;

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -96,7 +96,7 @@
         font-size: small;
     }
     .navbar-custom {
-        background-color: #809fff;
+        background-color: var(--ns-light-blue);
         color: white;
     }
     #logoWithMicroscope {

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -28,23 +28,19 @@
                     id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                         <li class="nav-item">
-                            <RouterLink
-                                class="nav-link"
-                                id="scopeLink"
-                                to="/scope">
+                            <RouterLink class="nav-link" to="/scope">
                                 The 'Scope
                             </RouterLink>
                         </li>
                         <li class="nav-item">
                             <a
                                 href="/doc/doc/about/index.html"
-                                class="nav-link"
-                                id="aboutLink">
+                                class="nav-link">
                                 About
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a href="/doc/" class="nav-link" id="docLink">
+                            <a href="/doc/" class="nav-link">
                                 Documentation
                             </a>
                         </li>
@@ -80,21 +76,16 @@
 </script>
 
 <style>
-    /*
-    I used ID's instead of a class because Bootstrap's CSS wasn't being
-    overridden when I used a class. ¯\_(ツ)_/¯
-    */
-    #scopeLink,
-    #aboutLink,
-    #docLink {
+    .navbar-nav li.nav-item .nav-link {
+        color: white;
+    }
+    .navbar-nav li.nav-item .nav-link:hover {
         color: white;
     }
     .navbar-text a {
         text-decoration: none;
     }
-    #scopeLink:hover,
-    #aboutLink:hover,
-    #docLink:hover {
+    .nav-link:hover {
         text-decoration: underline;
     }
     .navbar-text a:hover {


### PR DESCRIPTION
This PR:

* makes the navbar links white and adds an underline to them when you hover over them
* removes the visualizer descriptions from the homepage
* adds an underline to the homepage 'scope button when you hover over it
* uses the footer color for homepage "Go to the 'Scope" button
* makes the Numberscope background image a link to the 'scope
* adds GitHub and Twitter links to footer
* eliminates space from the acknowledgements link in footer