### PR TITLE
fix: Run python tools properly from Windows

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,12 @@ plugins:
     - awesome-pages
     - search
     - semiliterate:
-          exclude_extensions: ['.jpg', '.ttf', '.ico', 'LICENSE.md']
+          exclude_extensions:
+              - '.jpg'
+              - '.ttf'
+              - '.ico'
+              - '.spec.ts'
+              - 'LICENSE.md'
           ignore_folders: [node_modules, dist, coverage]
           include_extensions: ['.png']
           merge_docs_dir: false

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
         "help:doc:serve:1": "echo This is like the 'dev' script, but for the",
         "help:doc:serve:2": "echo embedded documentation rather than the",
         "help:doc:serve:3": "echo Numberscope interface itself.",
-        "doc:serve": ".venv/bin/mkdocs serve",
+        "doc:serve": "cd tools && node pyrun.mjs mkdocs serve",
         "help:build": "run-s -s help:build:*",
         "help:build:1": "echo Compiles frontscope and minifies the result,",
         "help:build:2": "echo producing a bundle ready for installation",
         "help:build:3": "echo on a server.",
-        "build": "npm run typecheck && vite build && .venv/bin/mkdocs build",
+        "build": "npm run typecheck && vite build && cd tools && node pyrun.mjs mkdocs build",
         "help:preview": "run-s -s help:build:*",
         "help:preview:1": "echo Serves the most recently built files -- the",
         "help:preview:2": "echo contents of the 'dist/' directory -- for you",
@@ -72,7 +72,7 @@
         "lint:staged": "lint-staged",
         "//only lifecycle scripts below here": "echo",
         "prepare": "husky install",
-        "postinstall": "python3 -m venv .venv && .venv/bin/pip install -U pip && .venv/bin/pip install -r requirements.txt"
+        "postinstall": "python3 -m venv .venv && cd tools && node pyrun.mjs pip install -U pip && node pyrun.mjs pip install -r requirements.txt"
     },
     "dependencies": {
         "p5": "^1.4.1",

--- a/tools/pyrun.mjs
+++ b/tools/pyrun.mjs
@@ -1,0 +1,20 @@
+import * as child_process from 'child_process'
+import * as path from 'path'
+import * as process from 'process'
+
+process.argv.shift() // remove the node path
+const toolPath = process.argv.shift()
+const packageDir = path.dirname(path.dirname(toolPath))
+let venvDir
+if (process.platform === 'win32') {
+    venvDir = path.join(packageDir, '.venv/Scripts')
+} else {
+    venvDir = path.join(packageDir, '.venv/bin')
+}
+const file = path.join(venvDir, process.argv.shift())
+const result = child_process.spawnSync(file, process.argv, {
+    cwd: packageDir,
+    stdio: 'inherit',
+    windowsHide: true,
+})
+process.exit(result.status)


### PR DESCRIPTION
  Adds a helper Node script in tools which examines the platform and
  spawns the appropriate command to run the specified program in the
  virtual environment set up in this project on install.

  Resolves #149.