### PR TITLE
feat: math utilities for the frontscope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,14 @@ applies to other repos as well.)
 1. [Create a fork of the numberscope/frontscope repo](./doc/working-with-git-and-github.md#create-a-fork).
 2. [Clone your fork of numberscope/frontscope](./doc/working-with-git-and-github.md#clone-a-repo).
 3. [Create a branch for your contribution](./doc/working-with-git-and-github.md#create-a-branch).
-4. [Read about basic Git operations](./doc/working-with-git-and-github.md#basic-git-operations).
+4. If you are unfamilar with them or would like a refresher,
+   [read about basic Git operations](./doc/working-with-git-and-github.md#basic-git-operations).
 5. [Push your branch to GitHub](./doc/working-with-git-and-github.md#push-a-branch).
 6. [Read Numberscope's coding principles guide](./doc/code-principles.md).
-7. [Read Numberscope's style guide](./doc/code-style.md).
+7. [Read Numberscope's style guide](./doc/code-style.md). You should also
+   familiarize yourself with frontscope's internal code structure and APIs;
+   the documentation available on these topics is listed in the "Internal code
+   and APIs" section of the navigation bar to the left.
 8. [Work through Numberscope's pull request checklist](./doc/pull-request-checklist.md).
 9. [Submit a pull request](./doc/working-with-git-and-github.md#submit-a-pull-request).
 

--- a/doc/working-with-bigints.md
+++ b/doc/working-with-bigints.md
@@ -1,0 +1,49 @@
+## Working with bigints
+
+All of frontscope's Sequence objects return bigints as their elements. The
+rationale is that many OEIS entries contain integer values too large to be
+accurately represented by JavaScript's `number` type, and attempting to
+compute with `number`s would lead to incorrect behavior such as considering
+all sufficiently large integers to be even.
+
+As a result, when working with sequence values you should attempt to use only
+the bigint type insofar as possible.
+
+Here's more information and techniques to facilitate using bigint in your
+code:
+
+-   The name of the TypeScript type for bigints is `bigint`. However, when you
+    want to make a value `v` of some other type into a bigint, you call
+    `BigInt(v)`.
+-   Literal values of type `bigint` consist digits followed by a lower-case n,
+    like 73n for the bigint with value 73, or 0n or -10n, etc.
+-   Right now unfortunately mathjs does not work on bigints but we are working
+    on that.
+-   In the meantime to compensate for the lack of bigints in mathjs, we have a
+    module (`src/shared/math`) in numberscope to supply some math utilities.
+    You should familiarize yourself with the
+    [functions it offers](../src/shared/math.md).
+-   In particular, if you are forced to convert a bigint to the JavaScript
+    number type, you should do it with the `safeNumber` function provided by
+    the math utility module, unless for some structural reason you are
+    **certain** the bigint won't overflow the number. That will provide
+    overflow checking and throw an error if accuracy would be lost. Note that
+    any value you get from the OEIS may be too large to fit in the JavaScript
+    number type.
+-   In any math operations, both operands must be of the same type. So
+    generally prefer converting to bigints any numbers you may need to use in
+    a calculation with bigints, if possible.
+-   However, note that the result of dividing one bigint by another is
+    automatically "floored" to produce an integer result. Be careful to think
+    if that's what you want; if not, you may need to rearrange your
+    expressions. For example `x * (3n/5n)` is very different from `(x*3n)/5n`
+    -- the former is always 0n, but the second will have the value 60n when x
+    is 100n, for example.
+-   You can't index an array with a bigint, so that is one case in which you
+    will be forced to convert to the number type. Since your array will not
+    have billions of elements, if you have made sure that your bigint is small
+    enough to index into the array, it will be small enough to safely convert
+    to a number.
+-   Use `===` to test if two bigints are equal and `!==` to check if they are
+    different. As with other operations, you can't use these to compare a
+    bigint and a number.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,9 @@ nav:
           - doc/code-style.md
           - doc/pull-request-checklist.md
           - doc/visual-studio-code-setup.md
+    - Internal code and APIs:
+          - doc/working-with-bigints.md
+          - src/shared/math.md
     - Other Information:
           - ... | flat | doc/*.md
 docs_dir: doc

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "version": "0.3.0",
             "hasInstallScript": true,
             "dependencies": {
+                "bigint-isqrt": "^0.3.2",
+                "bigint-mod-arith": "^3.1.2",
                 "p5": "^1.4.1",
                 "vue": "^3.2.37",
                 "vue-router": "^4.1.2"
@@ -36,7 +38,7 @@
                 "prettier-eslint": "^15.0.1",
                 "prettier-eslint-cli": "^6.0.1",
                 "typescript": "~4.5.5",
-                "vite": "^3.0.0",
+                "vite": "^3.1.8",
                 "vitest": "^0.18.1",
                 "vue-tsc": "^0.38.8",
                 "vue-unique-id": "^3.2.1"
@@ -63,6 +65,38 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.12.tgz",
+            "integrity": "sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
+            "integrity": "sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -877,6 +911,19 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/bigint-isqrt": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/bigint-isqrt/-/bigint-isqrt-0.3.2.tgz",
+            "integrity": "sha512-hfd7Ka2XKmBIAQWWDrDHTCkGsSfZMFjgcB3eCnDtZHsDiszSk+CQvnq16nGYIKuDMBvnSAvjnihoumJDpMnv7A=="
+        },
+        "node_modules/bigint-mod-arith": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
+            "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
+            "engines": {
+                "node": ">=10.4.0"
+            }
+        },
         "node_modules/boolify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
@@ -1494,9 +1541,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.49.tgz",
-            "integrity": "sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.12.tgz",
+            "integrity": "sha512-PcT+/wyDqJQsRVhaE9uX/Oq4XLrFh0ce/bs2TJh4CSaw9xuvI+xFrH2nAYOADbhQjUgAhNWC5LKoUsakm4dxng==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -1506,32 +1553,34 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "esbuild-android-64": "0.14.49",
-                "esbuild-android-arm64": "0.14.49",
-                "esbuild-darwin-64": "0.14.49",
-                "esbuild-darwin-arm64": "0.14.49",
-                "esbuild-freebsd-64": "0.14.49",
-                "esbuild-freebsd-arm64": "0.14.49",
-                "esbuild-linux-32": "0.14.49",
-                "esbuild-linux-64": "0.14.49",
-                "esbuild-linux-arm": "0.14.49",
-                "esbuild-linux-arm64": "0.14.49",
-                "esbuild-linux-mips64le": "0.14.49",
-                "esbuild-linux-ppc64le": "0.14.49",
-                "esbuild-linux-riscv64": "0.14.49",
-                "esbuild-linux-s390x": "0.14.49",
-                "esbuild-netbsd-64": "0.14.49",
-                "esbuild-openbsd-64": "0.14.49",
-                "esbuild-sunos-64": "0.14.49",
-                "esbuild-windows-32": "0.14.49",
-                "esbuild-windows-64": "0.14.49",
-                "esbuild-windows-arm64": "0.14.49"
+                "@esbuild/android-arm": "0.15.12",
+                "@esbuild/linux-loong64": "0.15.12",
+                "esbuild-android-64": "0.15.12",
+                "esbuild-android-arm64": "0.15.12",
+                "esbuild-darwin-64": "0.15.12",
+                "esbuild-darwin-arm64": "0.15.12",
+                "esbuild-freebsd-64": "0.15.12",
+                "esbuild-freebsd-arm64": "0.15.12",
+                "esbuild-linux-32": "0.15.12",
+                "esbuild-linux-64": "0.15.12",
+                "esbuild-linux-arm": "0.15.12",
+                "esbuild-linux-arm64": "0.15.12",
+                "esbuild-linux-mips64le": "0.15.12",
+                "esbuild-linux-ppc64le": "0.15.12",
+                "esbuild-linux-riscv64": "0.15.12",
+                "esbuild-linux-s390x": "0.15.12",
+                "esbuild-netbsd-64": "0.15.12",
+                "esbuild-openbsd-64": "0.15.12",
+                "esbuild-sunos-64": "0.15.12",
+                "esbuild-windows-32": "0.15.12",
+                "esbuild-windows-64": "0.15.12",
+                "esbuild-windows-arm64": "0.15.12"
             }
         },
         "node_modules/esbuild-android-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.49.tgz",
-            "integrity": "sha512-vYsdOTD+yi+kquhBiFWl3tyxnj2qZJsl4tAqwhT90ktUdnyTizgle7TjNx6Ar1bN7wcwWqZ9QInfdk2WVagSww==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz",
+            "integrity": "sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==",
             "cpu": [
                 "x64"
             ],
@@ -1545,9 +1594,9 @@
             }
         },
         "node_modules/esbuild-android-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.49.tgz",
-            "integrity": "sha512-g2HGr/hjOXCgSsvQZ1nK4nW/ei8JUx04Li74qub9qWrStlysaVmadRyTVuW32FGIpLQyc5sUjjZopj49eGGM2g==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz",
+            "integrity": "sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==",
             "cpu": [
                 "arm64"
             ],
@@ -1561,9 +1610,9 @@
             }
         },
         "node_modules/esbuild-darwin-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.49.tgz",
-            "integrity": "sha512-3rvqnBCtX9ywso5fCHixt2GBCUsogNp9DjGmvbBohh31Ces34BVzFltMSxJpacNki96+WIcX5s/vum+ckXiLYg==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz",
+            "integrity": "sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==",
             "cpu": [
                 "x64"
             ],
@@ -1577,9 +1626,9 @@
             }
         },
         "node_modules/esbuild-darwin-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.49.tgz",
-            "integrity": "sha512-XMaqDxO846srnGlUSJnwbijV29MTKUATmOLyQSfswbK/2X5Uv28M9tTLUJcKKxzoo9lnkYPsx2o8EJcTYwCs/A==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz",
+            "integrity": "sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==",
             "cpu": [
                 "arm64"
             ],
@@ -1593,9 +1642,9 @@
             }
         },
         "node_modules/esbuild-freebsd-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.49.tgz",
-            "integrity": "sha512-NJ5Q6AjV879mOHFri+5lZLTp5XsO2hQ+KSJYLbfY9DgCu8s6/Zl2prWXVANYTeCDLlrIlNNYw8y34xqyLDKOmQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz",
+            "integrity": "sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==",
             "cpu": [
                 "x64"
             ],
@@ -1609,9 +1658,9 @@
             }
         },
         "node_modules/esbuild-freebsd-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.49.tgz",
-            "integrity": "sha512-lFLtgXnAc3eXYqj5koPlBZvEbBSOSUbWO3gyY/0+4lBdRqELyz4bAuamHvmvHW5swJYL7kngzIZw6kdu25KGOA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz",
+            "integrity": "sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==",
             "cpu": [
                 "arm64"
             ],
@@ -1625,9 +1674,9 @@
             }
         },
         "node_modules/esbuild-linux-32": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.49.tgz",
-            "integrity": "sha512-zTTH4gr2Kb8u4QcOpTDVn7Z8q7QEIvFl/+vHrI3cF6XOJS7iEI1FWslTo3uofB2+mn6sIJEQD9PrNZKoAAMDiA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz",
+            "integrity": "sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==",
             "cpu": [
                 "ia32"
             ],
@@ -1641,9 +1690,9 @@
             }
         },
         "node_modules/esbuild-linux-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.49.tgz",
-            "integrity": "sha512-hYmzRIDzFfLrB5c1SknkxzM8LdEUOusp6M2TnuQZJLRtxTgyPnZZVtyMeCLki0wKgYPXkFsAVhi8vzo2mBNeTg==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz",
+            "integrity": "sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==",
             "cpu": [
                 "x64"
             ],
@@ -1657,9 +1706,9 @@
             }
         },
         "node_modules/esbuild-linux-arm": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.49.tgz",
-            "integrity": "sha512-iE3e+ZVv1Qz1Sy0gifIsarJMQ89Rpm9mtLSRtG3AH0FPgAzQ5Z5oU6vYzhc/3gSPi2UxdCOfRhw2onXuFw/0lg==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz",
+            "integrity": "sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==",
             "cpu": [
                 "arm"
             ],
@@ -1673,9 +1722,9 @@
             }
         },
         "node_modules/esbuild-linux-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.49.tgz",
-            "integrity": "sha512-KLQ+WpeuY+7bxukxLz5VgkAAVQxUv67Ft4DmHIPIW+2w3ObBPQhqNoeQUHxopoW/aiOn3m99NSmSV+bs4BSsdA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz",
+            "integrity": "sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1689,9 +1738,9 @@
             }
         },
         "node_modules/esbuild-linux-mips64le": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.49.tgz",
-            "integrity": "sha512-n+rGODfm8RSum5pFIqFQVQpYBw+AztL8s6o9kfx7tjfK0yIGF6tm5HlG6aRjodiiKkH2xAiIM+U4xtQVZYU4rA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz",
+            "integrity": "sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==",
             "cpu": [
                 "mips64el"
             ],
@@ -1705,9 +1754,9 @@
             }
         },
         "node_modules/esbuild-linux-ppc64le": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.49.tgz",
-            "integrity": "sha512-WP9zR4HX6iCBmMFH+XHHng2LmdoIeUmBpL4aL2TR8ruzXyT4dWrJ5BSbT8iNo6THN8lod6GOmYDLq/dgZLalGw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz",
+            "integrity": "sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1721,9 +1770,9 @@
             }
         },
         "node_modules/esbuild-linux-riscv64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.49.tgz",
-            "integrity": "sha512-h66ORBz+Dg+1KgLvzTVQEA1LX4XBd1SK0Fgbhhw4akpG/YkN8pS6OzYI/7SGENiN6ao5hETRDSkVcvU9NRtkMQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz",
+            "integrity": "sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1737,9 +1786,9 @@
             }
         },
         "node_modules/esbuild-linux-s390x": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.49.tgz",
-            "integrity": "sha512-DhrUoFVWD+XmKO1y7e4kNCqQHPs6twz6VV6Uezl/XHYGzM60rBewBF5jlZjG0nCk5W/Xy6y1xWeopkrhFFM0sQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz",
+            "integrity": "sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==",
             "cpu": [
                 "s390x"
             ],
@@ -1753,9 +1802,9 @@
             }
         },
         "node_modules/esbuild-netbsd-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.49.tgz",
-            "integrity": "sha512-BXaUwFOfCy2T+hABtiPUIpWjAeWK9P8O41gR4Pg73hpzoygVGnj0nI3YK4SJhe52ELgtdgWP/ckIkbn2XaTxjQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz",
+            "integrity": "sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==",
             "cpu": [
                 "x64"
             ],
@@ -1769,9 +1818,9 @@
             }
         },
         "node_modules/esbuild-openbsd-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.49.tgz",
-            "integrity": "sha512-lP06UQeLDGmVPw9Rg437Btu6J9/BmyhdoefnQ4gDEJTtJvKtQaUcOQrhjTq455ouZN4EHFH1h28WOJVANK41kA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz",
+            "integrity": "sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==",
             "cpu": [
                 "x64"
             ],
@@ -1785,9 +1834,9 @@
             }
         },
         "node_modules/esbuild-sunos-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.49.tgz",
-            "integrity": "sha512-4c8Zowp+V3zIWje329BeLbGh6XI9c/rqARNaj5yPHdC61pHI9UNdDxT3rePPJeWcEZVKjkiAS6AP6kiITp7FSw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz",
+            "integrity": "sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==",
             "cpu": [
                 "x64"
             ],
@@ -1801,9 +1850,9 @@
             }
         },
         "node_modules/esbuild-windows-32": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.49.tgz",
-            "integrity": "sha512-q7Rb+J9yHTeKr9QTPDYkqfkEj8/kcKz9lOabDuvEXpXuIcosWCJgo5Z7h/L4r7rbtTH4a8U2FGKb6s1eeOHmJA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz",
+            "integrity": "sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==",
             "cpu": [
                 "ia32"
             ],
@@ -1817,9 +1866,9 @@
             }
         },
         "node_modules/esbuild-windows-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.49.tgz",
-            "integrity": "sha512-+Cme7Ongv0UIUTniPqfTX6mJ8Deo7VXw9xN0yJEN1lQMHDppTNmKwAM3oGbD/Vqff+07K2gN0WfNkMohmG+dVw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz",
+            "integrity": "sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==",
             "cpu": [
                 "x64"
             ],
@@ -1833,9 +1882,9 @@
             }
         },
         "node_modules/esbuild-windows-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz",
-            "integrity": "sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz",
+            "integrity": "sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==",
             "cpu": [
                 "arm64"
             ],
@@ -4407,9 +4456,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+            "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4921,9 +4970,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.77.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
-            "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
+            "version": "2.78.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -5629,21 +5678,21 @@
             }
         },
         "node_modules/vite": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.0.tgz",
-            "integrity": "sha512-M7phQhY3+fRZa0H+1WzI6N+/onruwPTBTMvaj7TzgZ0v2TE+N2sdLKxJOfOv9CckDWt5C4HmyQP81xB4dwRKzA==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
+            "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.14.47",
-                "postcss": "^8.4.14",
+                "esbuild": "^0.15.9",
+                "postcss": "^8.4.16",
                 "resolve": "^1.22.1",
-                "rollup": "^2.75.6"
+                "rollup": "~2.78.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": ">=14.18.0"
+                "node": "^14.18.0 || >=16.0.0"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
@@ -6139,6 +6188,20 @@
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
+        },
+        "@esbuild/android-arm": {
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.12.tgz",
+            "integrity": "sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz",
+            "integrity": "sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==",
+            "dev": true,
+            "optional": true
         },
         "@eslint/eslintrc": {
             "version": "1.3.0",
@@ -6760,6 +6823,16 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "bigint-isqrt": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/bigint-isqrt/-/bigint-isqrt-0.3.2.tgz",
+            "integrity": "sha512-hfd7Ka2XKmBIAQWWDrDHTCkGsSfZMFjgcB3eCnDtZHsDiszSk+CQvnq16nGYIKuDMBvnSAvjnihoumJDpMnv7A=="
+        },
+        "bigint-mod-arith": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
+            "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ=="
+        },
         "boolify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
@@ -7237,170 +7310,172 @@
             }
         },
         "esbuild": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.49.tgz",
-            "integrity": "sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.12.tgz",
+            "integrity": "sha512-PcT+/wyDqJQsRVhaE9uX/Oq4XLrFh0ce/bs2TJh4CSaw9xuvI+xFrH2nAYOADbhQjUgAhNWC5LKoUsakm4dxng==",
             "dev": true,
             "requires": {
-                "esbuild-android-64": "0.14.49",
-                "esbuild-android-arm64": "0.14.49",
-                "esbuild-darwin-64": "0.14.49",
-                "esbuild-darwin-arm64": "0.14.49",
-                "esbuild-freebsd-64": "0.14.49",
-                "esbuild-freebsd-arm64": "0.14.49",
-                "esbuild-linux-32": "0.14.49",
-                "esbuild-linux-64": "0.14.49",
-                "esbuild-linux-arm": "0.14.49",
-                "esbuild-linux-arm64": "0.14.49",
-                "esbuild-linux-mips64le": "0.14.49",
-                "esbuild-linux-ppc64le": "0.14.49",
-                "esbuild-linux-riscv64": "0.14.49",
-                "esbuild-linux-s390x": "0.14.49",
-                "esbuild-netbsd-64": "0.14.49",
-                "esbuild-openbsd-64": "0.14.49",
-                "esbuild-sunos-64": "0.14.49",
-                "esbuild-windows-32": "0.14.49",
-                "esbuild-windows-64": "0.14.49",
-                "esbuild-windows-arm64": "0.14.49"
+                "@esbuild/android-arm": "0.15.12",
+                "@esbuild/linux-loong64": "0.15.12",
+                "esbuild-android-64": "0.15.12",
+                "esbuild-android-arm64": "0.15.12",
+                "esbuild-darwin-64": "0.15.12",
+                "esbuild-darwin-arm64": "0.15.12",
+                "esbuild-freebsd-64": "0.15.12",
+                "esbuild-freebsd-arm64": "0.15.12",
+                "esbuild-linux-32": "0.15.12",
+                "esbuild-linux-64": "0.15.12",
+                "esbuild-linux-arm": "0.15.12",
+                "esbuild-linux-arm64": "0.15.12",
+                "esbuild-linux-mips64le": "0.15.12",
+                "esbuild-linux-ppc64le": "0.15.12",
+                "esbuild-linux-riscv64": "0.15.12",
+                "esbuild-linux-s390x": "0.15.12",
+                "esbuild-netbsd-64": "0.15.12",
+                "esbuild-openbsd-64": "0.15.12",
+                "esbuild-sunos-64": "0.15.12",
+                "esbuild-windows-32": "0.15.12",
+                "esbuild-windows-64": "0.15.12",
+                "esbuild-windows-arm64": "0.15.12"
             }
         },
         "esbuild-android-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.49.tgz",
-            "integrity": "sha512-vYsdOTD+yi+kquhBiFWl3tyxnj2qZJsl4tAqwhT90ktUdnyTizgle7TjNx6Ar1bN7wcwWqZ9QInfdk2WVagSww==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz",
+            "integrity": "sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==",
             "dev": true,
             "optional": true
         },
         "esbuild-android-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.49.tgz",
-            "integrity": "sha512-g2HGr/hjOXCgSsvQZ1nK4nW/ei8JUx04Li74qub9qWrStlysaVmadRyTVuW32FGIpLQyc5sUjjZopj49eGGM2g==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz",
+            "integrity": "sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==",
             "dev": true,
             "optional": true
         },
         "esbuild-darwin-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.49.tgz",
-            "integrity": "sha512-3rvqnBCtX9ywso5fCHixt2GBCUsogNp9DjGmvbBohh31Ces34BVzFltMSxJpacNki96+WIcX5s/vum+ckXiLYg==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz",
+            "integrity": "sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==",
             "dev": true,
             "optional": true
         },
         "esbuild-darwin-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.49.tgz",
-            "integrity": "sha512-XMaqDxO846srnGlUSJnwbijV29MTKUATmOLyQSfswbK/2X5Uv28M9tTLUJcKKxzoo9lnkYPsx2o8EJcTYwCs/A==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz",
+            "integrity": "sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==",
             "dev": true,
             "optional": true
         },
         "esbuild-freebsd-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.49.tgz",
-            "integrity": "sha512-NJ5Q6AjV879mOHFri+5lZLTp5XsO2hQ+KSJYLbfY9DgCu8s6/Zl2prWXVANYTeCDLlrIlNNYw8y34xqyLDKOmQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz",
+            "integrity": "sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==",
             "dev": true,
             "optional": true
         },
         "esbuild-freebsd-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.49.tgz",
-            "integrity": "sha512-lFLtgXnAc3eXYqj5koPlBZvEbBSOSUbWO3gyY/0+4lBdRqELyz4bAuamHvmvHW5swJYL7kngzIZw6kdu25KGOA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz",
+            "integrity": "sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-32": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.49.tgz",
-            "integrity": "sha512-zTTH4gr2Kb8u4QcOpTDVn7Z8q7QEIvFl/+vHrI3cF6XOJS7iEI1FWslTo3uofB2+mn6sIJEQD9PrNZKoAAMDiA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz",
+            "integrity": "sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.49.tgz",
-            "integrity": "sha512-hYmzRIDzFfLrB5c1SknkxzM8LdEUOusp6M2TnuQZJLRtxTgyPnZZVtyMeCLki0wKgYPXkFsAVhi8vzo2mBNeTg==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz",
+            "integrity": "sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-arm": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.49.tgz",
-            "integrity": "sha512-iE3e+ZVv1Qz1Sy0gifIsarJMQ89Rpm9mtLSRtG3AH0FPgAzQ5Z5oU6vYzhc/3gSPi2UxdCOfRhw2onXuFw/0lg==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz",
+            "integrity": "sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.49.tgz",
-            "integrity": "sha512-KLQ+WpeuY+7bxukxLz5VgkAAVQxUv67Ft4DmHIPIW+2w3ObBPQhqNoeQUHxopoW/aiOn3m99NSmSV+bs4BSsdA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz",
+            "integrity": "sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-mips64le": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.49.tgz",
-            "integrity": "sha512-n+rGODfm8RSum5pFIqFQVQpYBw+AztL8s6o9kfx7tjfK0yIGF6tm5HlG6aRjodiiKkH2xAiIM+U4xtQVZYU4rA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz",
+            "integrity": "sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-ppc64le": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.49.tgz",
-            "integrity": "sha512-WP9zR4HX6iCBmMFH+XHHng2LmdoIeUmBpL4aL2TR8ruzXyT4dWrJ5BSbT8iNo6THN8lod6GOmYDLq/dgZLalGw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz",
+            "integrity": "sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-riscv64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.49.tgz",
-            "integrity": "sha512-h66ORBz+Dg+1KgLvzTVQEA1LX4XBd1SK0Fgbhhw4akpG/YkN8pS6OzYI/7SGENiN6ao5hETRDSkVcvU9NRtkMQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz",
+            "integrity": "sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-s390x": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.49.tgz",
-            "integrity": "sha512-DhrUoFVWD+XmKO1y7e4kNCqQHPs6twz6VV6Uezl/XHYGzM60rBewBF5jlZjG0nCk5W/Xy6y1xWeopkrhFFM0sQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz",
+            "integrity": "sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==",
             "dev": true,
             "optional": true
         },
         "esbuild-netbsd-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.49.tgz",
-            "integrity": "sha512-BXaUwFOfCy2T+hABtiPUIpWjAeWK9P8O41gR4Pg73hpzoygVGnj0nI3YK4SJhe52ELgtdgWP/ckIkbn2XaTxjQ==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz",
+            "integrity": "sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==",
             "dev": true,
             "optional": true
         },
         "esbuild-openbsd-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.49.tgz",
-            "integrity": "sha512-lP06UQeLDGmVPw9Rg437Btu6J9/BmyhdoefnQ4gDEJTtJvKtQaUcOQrhjTq455ouZN4EHFH1h28WOJVANK41kA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz",
+            "integrity": "sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==",
             "dev": true,
             "optional": true
         },
         "esbuild-sunos-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.49.tgz",
-            "integrity": "sha512-4c8Zowp+V3zIWje329BeLbGh6XI9c/rqARNaj5yPHdC61pHI9UNdDxT3rePPJeWcEZVKjkiAS6AP6kiITp7FSw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz",
+            "integrity": "sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==",
             "dev": true,
             "optional": true
         },
         "esbuild-windows-32": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.49.tgz",
-            "integrity": "sha512-q7Rb+J9yHTeKr9QTPDYkqfkEj8/kcKz9lOabDuvEXpXuIcosWCJgo5Z7h/L4r7rbtTH4a8U2FGKb6s1eeOHmJA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz",
+            "integrity": "sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==",
             "dev": true,
             "optional": true
         },
         "esbuild-windows-64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.49.tgz",
-            "integrity": "sha512-+Cme7Ongv0UIUTniPqfTX6mJ8Deo7VXw9xN0yJEN1lQMHDppTNmKwAM3oGbD/Vqff+07K2gN0WfNkMohmG+dVw==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz",
+            "integrity": "sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==",
             "dev": true,
             "optional": true
         },
         "esbuild-windows-arm64": {
-            "version": "0.14.49",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz",
-            "integrity": "sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==",
+            "version": "0.15.12",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz",
+            "integrity": "sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==",
             "dev": true,
             "optional": true
         },
@@ -9291,9 +9366,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+            "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
             "requires": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
@@ -9674,9 +9749,9 @@
             }
         },
         "rollup": {
-            "version": "2.77.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
-            "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
+            "version": "2.78.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -10211,16 +10286,16 @@
             }
         },
         "vite": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.0.tgz",
-            "integrity": "sha512-M7phQhY3+fRZa0H+1WzI6N+/onruwPTBTMvaj7TzgZ0v2TE+N2sdLKxJOfOv9CckDWt5C4HmyQP81xB4dwRKzA==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
+            "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
             "dev": true,
             "requires": {
-                "esbuild": "^0.14.47",
+                "esbuild": "^0.15.9",
                 "fsevents": "~2.3.2",
-                "postcss": "^8.4.14",
+                "postcss": "^8.4.16",
                 "resolve": "^1.22.1",
-                "rollup": "^2.75.6"
+                "rollup": "~2.78.0"
             }
         },
         "vitest": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
         "postinstall": "python3 -m venv .venv && cd tools && node pyrun.mjs pip install -U pip && node pyrun.mjs pip install -r requirements.txt"
     },
     "dependencies": {
+        "bigint-isqrt": "^0.3.2",
+        "bigint-mod-arith": "^3.1.2",
         "p5": "^1.4.1",
         "vue": "^3.2.37",
         "vue-router": "^4.1.2"
@@ -102,7 +104,7 @@
         "prettier-eslint": "^15.0.1",
         "prettier-eslint-cli": "^6.0.1",
         "typescript": "~4.5.5",
-        "vite": "^3.0.0",
+        "vite": "^3.1.8",
         "vitest": "^0.18.1",
         "vue-tsc": "^0.38.8",
         "vue-unique-id": "^3.2.1"

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -1,4 +1,5 @@
 import type {ValidationStatus} from '../shared/ValidationStatus'
+import {modulo} from '../shared/math'
 import {SequenceExportModule, SequenceExportKind} from './SequenceInterface'
 import {SequenceCached} from './SequenceCached'
 
@@ -18,7 +19,7 @@ export default class OEISSequenceTemplate extends SequenceCached {
     cacheBlock = 1000
     oeisId = ''
     givenName = ''
-    modulo = 0n
+    modulus = 0n
     params = {
         oeisId: {value: '', displayName: 'OEIS ID', required: true},
         givenName: {value: '', displayName: 'Name', required: false},
@@ -29,9 +30,9 @@ export default class OEISSequenceTemplate extends SequenceCached {
             description:
                 'How many elements to try to fetch from the database.',
         },
-        modulo: {
-            value: this.modulo,
-            displayName: 'Modulo',
+        modulus: {
+            value: this.modulus,
+            displayName: 'Modulus',
             required: false,
             description:
                 'If nonzero, take the residue of each element to this modulus.',
@@ -57,7 +58,9 @@ export default class OEISSequenceTemplate extends SequenceCached {
             if (index < this.first) this.first = index
             if (index > this.last) this.last = index
             this.cache[index] = BigInt(response.data.values[k])
-            if (this.modulo) this.cache[index] %= this.modulo
+            if (this.modulus) {
+                this.cache[index] = modulo(this.cache[index], this.modulus)
+            }
         }
         if (this.first === Infinity) {
             /* An empty sequence; perhaps a mistaken OEIS ID. Is there

--- a/src/sequences/simpleFactor.ts
+++ b/src/sequences/simpleFactor.ts
@@ -43,6 +43,7 @@ export default function simpleFactor(v: bigint): [bigint, bigint][] | null {
     }
     for (const p of smallPrimes) {
         let power = 0n
+        // OK to use % since all we care about is divisibility:
         while (v % p === 0n) {
             power += 1n
             v /= p

--- a/src/shared/__tests__/math.spec.ts
+++ b/src/shared/__tests__/math.spec.ts
@@ -1,0 +1,72 @@
+import * as math from '../math'
+import {describe, it, expect} from 'vitest'
+
+const large = 9007199254740993n
+
+describe('safeNumber', () => {
+    it('leaves small numbers alone', () => {
+        expect(math.safeNumber(7)).toBe(7)
+    })
+    it('makes small bigints into numbers', () => {
+        expect(math.safeNumber(-11n)).toBe(-11)
+    })
+    it('throws on numbers of great magnitude', () => {
+        expect(() => math.safeNumber(10e40)).toThrowError('Attempt')
+    })
+    it('throws on bigints of great magnitude', () => {
+        expect(() => math.safeNumber(-large)).toThrowError('Attempt')
+    })
+})
+
+describe('floorSqrt', () => {
+    it('does nothing on negative bigints', () => {
+        expect(math.floorSqrt(-13n)).toBe(-13n)
+    })
+    it('makes negative numbers into bigints', () => {
+        expect(math.floorSqrt(-15)).toBe(-15n)
+    })
+    it('finds the exact square root of a square number or bignumber', () => {
+        expect(math.floorSqrt(large * large)).toBe(large)
+        expect(math.floorSqrt(16)).toBe(4n)
+    })
+    it('finds the floor of the square root of a number or bignumber', () => {
+        expect(math.floorSqrt(large * large + 10000n)).toBe(large)
+        expect(math.floorSqrt(35)).toBe(5n)
+    })
+})
+
+describe('modulo', () => {
+    it('gives the bigint remainder upon division', () => {
+        expect(math.modulo(7, 5)).toBe(2n)
+        expect(math.modulo(large, 10)).toBe(3n)
+        expect(math.modulo(12, 5n)).toBe(2n)
+        expect(math.modulo(99999999999999999999999999n, 100n)).toBe(99n)
+    })
+    it('always provides a nonnegative residue', () => {
+        expect(math.modulo(-7, 5)).toBe(3n)
+        expect(math.modulo(-large, 100n)).toBe(7n)
+        expect(math.modulo(25, 5n)).toBe(0n)
+    })
+    it('requires a positive modulus', () => {
+        expect(() => math.modulo(77, -7)).toThrowError('Attempt')
+        expect(() => math.modulo(-109n, -6n)).toThrowError('Attempt')
+    })
+})
+
+describe('powmod', () => {
+    it('computes n**exponent modulo the modulus', () => {
+        expect(math.powmod(2, 3, 7)).toBe(1n)
+        const largeCube = large * large * large
+        expect(math.powmod(large, 3, 7n)).toBe(math.modulo(largeCube, 7))
+        expect(math.powmod(6n, 2401n, 7)).toBe(6n)
+        expect(math.powmod(-3n, 343n, 7n)).toBe(4n)
+    })
+    it('requires a positive modulus', () => {
+        expect(() => math.powmod(77, 2n, -7)).toThrowError('must be')
+        expect(() => math.powmod(-109n, 1000, -6n)).toThrowError('must be')
+    })
+    it('handles negative exponents', () => {
+        expect(math.powmod(23, -2n, 18)).toBe(13n)
+        expect(() => math.powmod(12n, -3, 18n)).toThrowError('MUST be')
+    })
+})

--- a/src/shared/bigint-isqrt.d.ts
+++ b/src/shared/bigint-isqrt.d.ts
@@ -1,0 +1,1 @@
+declare module 'bigint-isqrt'

--- a/src/shared/math.ts
+++ b/src/shared/math.ts
@@ -1,0 +1,110 @@
+/** md
+## Math utilities for numberscope
+
+The primary resource for doing math inside the frontscope code is the
+[mathjs](http://mathjs.org) package, which this repository depends on.
+The `shared/math` module of Numberscope provides some additional utilities
+aimed at making common mathematical operations more convenient, especially
+when working with bigints.
+
+Note that currently every one of these functions accepts either
+`number` or `bigint` inputs for all arguments and simply converts them
+to bigints.
+
+### Example usage
+```ts
+import { safeNumber, floorSqrt, modulo, powmod } from '../shared/math'
+try {
+  const myNumber = safeNumber(9007199254740992n)
+} catch (err: unknown) {
+  console.log('This will always be logged')
+}
+try {
+  const myNumber = safeNumber(9007n)
+} catch (err: unknown) {
+  console.log('This never will be and myNumber will be 9007')
+}
+
+const five: bigint = floorSqrt(30n)
+const negativeTwo: bigint = floorSqrt(-2n)
+
+const three: bigint = modulo(-7n, 5)
+const two: bigint = modulo(7, 5n)
+
+const six: bigint = powmod(6, 2401n, 7n)
+// n to the p is congruent to n mod a prime p,
+// so a to any power of p is as well.
+```
+
+### Detailed function reference
+**/
+
+import isqrt from 'bigint-isqrt'
+import {modPow} from 'bigint-mod-arith'
+
+const maxSafeNumber = BigInt(Number.MAX_SAFE_INTEGER)
+const minSafeNumber = BigInt(Number.MIN_SAFE_INTEGER)
+
+/** md
+#### safeNumber(n: number | bigint): number
+
+Returns the `number` mathematically equal to _n_ if there is one, or
+throws an error otherwise.
+**/
+export function safeNumber(n: number | bigint): number {
+    const bn = BigInt(n)
+    if (bn < minSafeNumber || bn > maxSafeNumber) {
+        throw new RangeError(`Attempt to use ${bn} as a number`)
+    }
+    return Number(bn)
+}
+
+/** md
+#### floorSqrt(n: number | bigint): bigint
+
+Returns the largest bigint _r_ such that the square of _r_ is less than or
+equal to _n_, if there is one; otherwise returns the bigint mathematically
+equal to _n_. (Thus, it leaves negative bigints unchanged.)
+**/
+export function floorSqrt(n: number | bigint): bigint {
+    const bn = BigInt(n)
+    return isqrt(bn)
+}
+
+/** md
+#### modulo(n: number | bigint, modulus: number | bigint): bigint
+
+Returns the smallest nonnegative bigint congruent to _n_ modulo
+_modulus_; this is also the remainder upon dividing _n_ by _modulus_. Note
+that this is the "mathematician's modulus" that never returns a negative
+value, unlike the built-in JavaScript `%` operator.
+
+Throws a RangeError if _modulus_ is nonpositive.
+**/
+export function modulo(n: number | bigint, modulus: number | bigint): bigint {
+    const bn = BigInt(n)
+    const bmodulus = BigInt(modulus)
+    if (bmodulus <= 0n) {
+        throw new RangeError(`Attempt to use nonpositive modulus ${bmodulus}`)
+    }
+    if (bn < 0n) {
+        return (bn % bmodulus) + bmodulus
+    }
+    return bn % bmodulus
+}
+
+/** md
+#### powmod(n, exponent, modulus): bigint
+
+All parameters have type `number | bigint`. If _modulus_ is nonpositive,
+throws a RangeError.
+
+Otherwise, if _exponent_ is positive, returns the smallest nonnegative bigint
+congruent to _n_ raised to the _exponent_ power modulo _modulus_ (but far more
+efficiently than computing `modulo(n**exponent, modulus)`).
+
+If _exponent_ is negative, first computes `i = powmod(n, -exponent, modulus)`.
+If _i_ has a multiplicative inverse modulo _modulus_, returns that inverse,
+otherwise throws a RangeError.
+**/
+export const powmod = modPow // just need to fix the name

--- a/src/visualizers/VisualizerChaos.ts
+++ b/src/visualizers/VisualizerChaos.ts
@@ -1,4 +1,5 @@
 import p5 from 'p5'
+import {modulo} from '../shared/math'
 import {VisualizerDefault} from './VisualizerDefault'
 import {VisualizerExportModule} from './VisualizerInterface'
 
@@ -232,22 +233,6 @@ class VisualizerChaos extends VisualizerDefault {
         return status
     }
 
-    numModulus(a: number | bigint, b: number) {
-        // This should be replaced with the modulus function in our own library,
-        // once that exists
-        if (b <= 0) {
-            throw new Error('negative modulus error')
-        }
-        const A = BigInt(a)
-        const B = BigInt(b)
-        // The return value will be a valid number, because b was a number:
-        if (A < 0n) {
-            return Number((A % B) + B)
-        } else {
-            return Number(A % B)
-        }
-    }
-
     chaosWindow(center: p5.Vector, radius: number) {
         // creates corners of a polygon with given centre and radius
         const pts: p5.Vector[] = []
@@ -405,11 +390,13 @@ class VisualizerChaos extends VisualizerDefault {
             const myTerm = this.seq.getElement(this.myIndex)
 
             // check its modulus to see which corner to walk toward
-            const myCorner = this.numModulus(myTerm, this.corners)
+            // (Safe to convert to number since this.corners is "small")
+            const myCorner = Number(modulo(myTerm, this.corners))
             const myCornerPosition = this.cornersList[myCorner]
 
             // check the index modulus to see which walker is walking
-            const myWalker = this.numModulus(this.myIndex, this.walkers)
+            // (Ditto on safety.)
+            const myWalker = Number(modulo(this.myIndex, this.walkers))
 
             // update the walker position
             this.walkerPositions[myWalker].lerp(myCornerPosition, this.frac)
@@ -434,9 +421,9 @@ class VisualizerChaos extends VisualizerDefault {
                         myColor = this.sketch.lerpColor(
                             this.currentPalette.colorList[0],
                             this.currentPalette.colorList[1],
-                            this.numModulus(
-                                this.myIndex,
-                                this.gradientLength
+                            Number(
+                                // Safe since gradientLength is "small"
+                                modulo(this.myIndex, this.gradientLength)
                             ) / this.gradientLength
                         )
                     }

--- a/src/visualizers/VisualizerModFill.ts
+++ b/src/visualizers/VisualizerModFill.ts
@@ -1,3 +1,4 @@
+import {modulo} from '../shared/math'
 import type {SequenceInterface} from '../sequences/SequenceInterface'
 import {VisualizerDefault} from '../visualizers/VisualizerDefault'
 import type {VisualizerInterface} from '@/visualizers/VisualizerInterface'
@@ -25,6 +26,7 @@ class VizModFill extends VisualizerDefault implements VisualizerInterface {
 - modDimension: The number of rows to display, which corresponds to the largest
     modulus to consider.
          **/
+        // note will be small enough to fit in a `number` when we need it to.
         modDimension: {
             value: this.modDimension,
             displayName: 'Mod dimension',
@@ -55,7 +57,8 @@ class VizModFill extends VisualizerDefault implements VisualizerInterface {
             const s = seq.getElement(num)
             const x = Number(mod - 1n) * this.rectWidth
             const y =
-                this.sketch.height - Number((s % mod) + 1n) * this.rectHeight
+                this.sketch.height
+                - Number(modulo(s, mod) + 1n) * this.rectHeight
             this.sketch.rect(x, y, this.rectWidth, this.rectHeight)
         }
     }

--- a/src/visualizers/VisualizerShiftCompare.ts
+++ b/src/visualizers/VisualizerShiftCompare.ts
@@ -1,4 +1,5 @@
 import p5 from 'p5'
+import {modulo} from '../shared/math'
 import {VisualizerDefault} from './VisualizerDefault'
 import type {VisualizerInterface} from '@/visualizers/VisualizerInterface'
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
@@ -99,16 +100,16 @@ class VizShiftCompare
 
         // Write to image, then to screen for speed.
         for (let x = this.seq.first; x <= xLim; x++) {
-            const xEl = this.seq.getElement(x)
+            const xResidue = modulo(this.seq.getElement(x), this.mod)
             for (let y = this.seq.first; y <= yLim; y++) {
-                const yEl = this.seq.getElement(y)
+                const yResidue = modulo(this.seq.getElement(y), this.mod)
                 for (let i = 0; i < d; i++) {
                     for (let j = 0; j < d; j++) {
                         const index =
                             ((y * d + j) * this.sketch.width * d
                                 + (x * d + i))
                             * 4
-                        if (xEl % this.mod == yEl % this.mod) {
+                        if (xResidue == yResidue) {
                             this.img.pixels[index] = 255
                             this.img.pixels[index + 1] = 255
                             this.img.pixels[index + 2] = 255

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
     build: {
         target: 'esnext',
     },
+    optimizeDeps: {
+        esbuildOptions: {
+            target: 'esnext',
+        },
+    },
     preview: {
         port: 5050,
         proxy: {


### PR DESCRIPTION
  Adds a new module `shared/math` that has some convenience
  functions for math in frontscope, especially for working
  with bigints.
  Specifically this first revision has safeNumber, for
  converting to a number with a check for loss of accuracy;
  floorSqrt for finding a bigint square root; modulo for the
  mathematician's modulo of bigints; and powmod for calculating
  a power of a number to some modulus (much more efficiently than
  exponentiating and then modding).

  Also provides documentation and tests for the new features and
  a guide to using bigints in frontscope.

  Resolves #163.
  Partially addresses #41.
  Does the first half of #172.