### PR TITLE
fix: use `python -m` in `postinstall` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "lint:staged": "lint-staged",
         "//only lifecycle scripts below here": "echo",
         "prepare": "husky install",
-        "postinstall": "python3 -m venv .venv && cd tools && node pyrun.mjs pip install -U pip && node pyrun.mjs pip install -r requirements.txt"
+        "postinstall": "python3 -m venv .venv && cd tools && node pyrun.mjs python -m pip install -U pip && node pyrun.mjs pip install -r requirements.txt"
     },
     "dependencies": {
         "bigint-isqrt": "^0.3.2",


### PR DESCRIPTION
Fixes https://github.com/numberscope/frontscope/issues/182.