### PR TITLE
refactor: handle errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,9 @@ import App from './App.vue'
 import router from './router'
 
 const app = createApp(App)
+app.config.errorHandler = err => {
+    window.alert(`Numberscope experienced an error: ${err}`)
+}
 
 app.use(router)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import {createApp} from 'vue'
 import App from './App.vue'
 import router from './router'
-import {alertError} from './shared/alertError.js'
+import {alertError} from './shared/alertError'
 
 const app = createApp(App)
 app.config.errorHandler = e => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import {createApp} from 'vue'
 import App from './App.vue'
 import router from './router'
-import {alertError} from './shared/alertError'
+import {alertMessage} from './shared/alertMessage.js'
 
 const app = createApp(App)
 app.config.errorHandler = e => {
-    alertError(e)
+    window.alert(alertMessage(e))
 }
 
 app.use(router)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import {createApp} from 'vue'
 import App from './App.vue'
 import router from './router'
+import {alertError} from './shared/alertError.js'
 
 const app = createApp(App)
-app.config.errorHandler = err => {
-    window.alert(`Numberscope experienced an error: ${err}`)
+app.config.errorHandler = e => {
+    alertError(e)
 }
 
 app.use(router)

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -2,6 +2,7 @@ import type {ValidationStatus} from '../shared/ValidationStatus'
 import {modulo} from '../shared/math'
 import {SequenceExportModule, SequenceExportKind} from './SequenceInterface'
 import {SequenceCached} from './SequenceCached'
+import {alertError} from '../shared/alertError.js'
 
 import axios from 'axios'
 
@@ -110,7 +111,7 @@ export default class OEISSequenceTemplate extends SequenceCached {
             this.lastCached = this.last
             this.cachingTo = this.last
         } catch (e) {
-            window.alert(`Numberscope experienced an error: ${e}`)
+            alertError(e)
         }
     }
 

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -2,7 +2,7 @@ import type {ValidationStatus} from '../shared/ValidationStatus'
 import {modulo} from '../shared/math'
 import {SequenceExportModule, SequenceExportKind} from './SequenceInterface'
 import {SequenceCached} from './SequenceCached'
-import {alertError} from '../shared/alertError'
+import {alertMessage} from '../shared/alertMessage.js'
 
 import axios from 'axios'
 
@@ -111,7 +111,7 @@ export default class OEISSequenceTemplate extends SequenceCached {
             this.lastCached = this.last
             this.cachingTo = this.last
         } catch (e) {
-            alertError(e)
+            window.alert(alertMessage(e))
         }
     }
 

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -110,7 +110,7 @@ export default class OEISSequenceTemplate extends SequenceCached {
             this.lastCached = this.last
             this.cachingTo = this.last
         } catch (e) {
-            window.alert(e)
+            window.alert(`Numberscope experienced an error: ${e}`)
         }
     }
 

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -44,65 +44,74 @@ export default class OEISSequenceTemplate extends SequenceCached {
     }
 
     async fillCache(): Promise<void> {
-        // import.meta.env is basically your configuration.
-        // It's set up by Vite automatically
-        // See https://vitejs.dev/guide/env-and-mode.html.
-        const urlPrefix = `${import.meta.env.VITE_BACKSCOPE_URL}/api/`
-        const backendUrl =
-            urlPrefix + `get_oeis_values/${this.oeisId}/${this.cacheBlock}`
-        const response = await axios.get(backendUrl)
-        this.first = Infinity
-        this.last = -Infinity
-        for (const k in response.data.values) {
-            const index = Number(k)
-            if (index < this.first) this.first = index
-            if (index > this.last) this.last = index
-            this.cache[index] = BigInt(response.data.values[k])
-            if (this.modulus) {
-                this.cache[index] = modulo(this.cache[index], this.modulus)
+        // Catch HTTP errors. (This function has multiple HTTP requests.)
+        try {
+            // import.meta.env is basically your configuration.
+            // It's set up by Vite automatically
+            // See https://vitejs.dev/guide/env-and-mode.html.
+            const urlPrefix = `${import.meta.env.VITE_BACKSCOPE_URL}/api/`
+            const backendUrl =
+                urlPrefix
+                + `get_oeis_values/${this.oeisId}/${this.cacheBlock}`
+            const response = await axios.get(backendUrl)
+            this.first = Infinity
+            this.last = -Infinity
+            for (const k in response.data.values) {
+                const index = Number(k)
+                if (index < this.first) this.first = index
+                if (index > this.last) this.last = index
+                this.cache[index] = BigInt(response.data.values[k])
+                if (this.modulus) {
+                    this.cache[index] = modulo(
+                        this.cache[index],
+                        this.modulus
+                    )
+                }
             }
-        }
-        if (this.first === Infinity) {
-            /* An empty sequence; perhaps a mistaken OEIS ID. Is there
+            if (this.first === Infinity) {
+                /* An empty sequence; perhaps a mistaken OEIS ID. Is there
                any other action we should take in this case?
             */
-            this.first = 0
-            this.last = -1
-        } else {
-            // OK, now get the factors
-            const factorUrl =
-                urlPrefix
-                + `get_oeis_factors/${this.oeisId}/${this.cacheBlock}`
-            const factorResponse = await axios.get(factorUrl)
-            for (const k in factorResponse.data.factors) {
-                const index = Number(k)
-                if (index < this.first || index > this.last) continue
-                const factors = factorResponse.data.factors[k]
-                if (factors === 'no_fac') {
-                    this.factorCache[index] = null
-                } else {
-                    // Sadly, we have to parse the factors as a _string_
-                    // ourselves:
-                    if (factors === '[]') {
-                        this.factorCache[index] = []
+                this.first = 0
+                this.last = -1
+            } else {
+                // OK, now get the factors
+                const factorUrl =
+                    urlPrefix
+                    + `get_oeis_factors/${this.oeisId}/${this.cacheBlock}`
+                const factorResponse = await axios.get(factorUrl)
+                for (const k in factorResponse.data.factors) {
+                    const index = Number(k)
+                    if (index < this.first || index > this.last) continue
+                    const factors = factorResponse.data.factors[k]
+                    if (factors === 'no_fac') {
+                        this.factorCache[index] = null
                     } else {
-                        // Lop off the initial '[[' and final ']]'
-                        const internals = factors.slice(2, -2)
-                        // That leaves '],[' separating the pairs
-                        const entries = internals.split('],[')
-                        this.factorCache[index] = entries.map(
-                            (pair: string) => {
-                                // And each pair is comma-separated
-                                const [base, power] = pair.split(',', 2)
-                                return [BigInt(base), BigInt(power)]
-                            }
-                        )
+                        // Sadly, we have to parse the factors as a _string_
+                        // ourselves:
+                        if (factors === '[]') {
+                            this.factorCache[index] = []
+                        } else {
+                            // Lop off the initial '[[' and final ']]'
+                            const internals = factors.slice(2, -2)
+                            // That leaves '],[' separating the pairs
+                            const entries = internals.split('],[')
+                            this.factorCache[index] = entries.map(
+                                (pair: string) => {
+                                    // And each pair is comma-separated
+                                    const [base, power] = pair.split(',', 2)
+                                    return [BigInt(base), BigInt(power)]
+                                }
+                            )
+                        }
                     }
                 }
             }
+            this.lastCached = this.last
+            this.cachingTo = this.last
+        } catch (e) {
+            window.alert(e)
         }
-        this.lastCached = this.last
-        this.cachingTo = this.last
     }
 
     checkParameters(): ValidationStatus {

--- a/src/sequences/OEISSequenceTemplate.ts
+++ b/src/sequences/OEISSequenceTemplate.ts
@@ -2,7 +2,7 @@ import type {ValidationStatus} from '../shared/ValidationStatus'
 import {modulo} from '../shared/math'
 import {SequenceExportModule, SequenceExportKind} from './SequenceInterface'
 import {SequenceCached} from './SequenceCached'
-import {alertError} from '../shared/alertError.js'
+import {alertError} from '../shared/alertError'
 
 import axios from 'axios'
 

--- a/src/shared/__tests__/alertError.spec.ts
+++ b/src/shared/__tests__/alertError.spec.ts
@@ -1,0 +1,10 @@
+import {alertError} from '../alertError'
+import {describe, it, expect} from 'vitest'
+
+describe('alertError', () => {
+    it('throws a type error when a non-string is supplied', () => {
+        expect(() => {
+            alertError({})
+        }).toThrowError(TypeError)
+    })
+})

--- a/src/shared/__tests__/alertError.spec.ts
+++ b/src/shared/__tests__/alertError.spec.ts
@@ -1,10 +1,13 @@
-import {alertError} from '../alertError'
+import {alertMessage} from '../alertMessage.js'
 import {describe, it, expect} from 'vitest'
 
-describe('alertError', () => {
-    it('throws a type error when a non-string is supplied', () => {
-        expect(() => {
-            alertError({})
-        }).toThrowError(TypeError)
+describe('alertMessage', () => {
+    it('contains text about experiencing an error', () => {
+        expect(alertMessage('foo')).toContain(
+            'Numberscope experienced an error.'
+        )
+    })
+    it('contains the error', () => {
+        expect(alertMessage('bar')).toContain('bar')
     })
 })

--- a/src/shared/alertError.ts
+++ b/src/shared/alertError.ts
@@ -1,0 +1,28 @@
+/** md
+ * ## A utility for displaying errors to the user
+ *
+ * If Numberscope experiences an error, we don't want it
+ * to silently fail and leave the user wondering why things
+ * aren't working. Instead, we tell them about the error
+ * with the hope that they either reload the page or tell
+ * us about the error.
+ *
+ * @param {string|unknown} error - the error you want to display to the user
+ */
+export const alertError = (error: string | unknown) => {
+    // prettier-ignore
+    const sendEmailMessage = 'If this issue persists, please send an email to numberscope@colorado.edu with steps to reproduce the error and the error message.' // eslint-disable-line
+    try {
+        // prettier-ignore
+        window.alert(`Numberscope experienced an error.
+
+Error Message:
+${error}
+
+You might need to reload the page.
+
+${sendEmailMessage}`)
+    } catch (e) {
+        window.alert(`alertError error: ${e}`)
+    }
+}

--- a/src/shared/alertError.ts
+++ b/src/shared/alertError.ts
@@ -10,10 +10,11 @@
  * @param {string|unknown} error - the error you want to display to the user
  */
 export const alertError = (error: string | unknown) => {
-    // prettier-ignore
-    const sendEmailMessage = 'If this issue persists, please send an email to numberscope@colorado.edu with steps to reproduce the error and the error message.' // eslint-disable-line
+    const sendEmailMessage =
+        'If this issue persists, please send an '
+        + 'email to numberscope@colorado.edu with steps to reproduce '
+        + 'the error and the error message.'
     try {
-        // prettier-ignore
         window.alert(`Numberscope experienced an error.
 
 Error Message:

--- a/src/shared/alertError.ts
+++ b/src/shared/alertError.ts
@@ -10,12 +10,14 @@
  * @param {string|unknown} error - the error you want to display to the user
  */
 export const alertError = (error: string | unknown) => {
+    if (typeof error !== 'string') {
+        throw new TypeError('error not string')
+    }
     const sendEmailMessage =
         'If this issue persists, please send an '
         + 'email to numberscope@colorado.edu with steps to reproduce '
         + 'the error and the error message.'
-    try {
-        window.alert(`Numberscope experienced an error.
+    window.alert(`Numberscope experienced an error.
 
 Error Message:
 ${error}
@@ -23,7 +25,4 @@ ${error}
 You might need to reload the page.
 
 ${sendEmailMessage}`)
-    } catch (e) {
-        window.alert(`alertError error: ${e}`)
-    }
 }

--- a/src/shared/alertMessage.ts
+++ b/src/shared/alertMessage.ts
@@ -1,5 +1,5 @@
 /** md
- * ## A utility for displaying errors to the user
+ * ## A utility for creating an error message to alert
  *
  * If Numberscope experiences an error, we don't want it
  * to silently fail and leave the user wondering why things
@@ -8,21 +8,17 @@
  * us about the error.
  *
  * @param {string|unknown} error - the error you want to display to the user
+ * @returns {string} - message you want to alert
  */
-export const alertError = (error: string | unknown) => {
-    if (typeof error !== 'string') {
-        throw new TypeError('error not string')
-    }
-    const sendEmailMessage =
+export const alertMessage = (error: string | unknown) => {
+    const errorMessage =
+        'Numberscope experienced an error.\n\n'
+        + 'Error Message:\n'
+        + `${error}\n\n`
+    const reloadDirective = 'You might need to reload the page.\n\n'
+    const sendEmailDirective =
         'If this issue persists, please send an '
         + 'email to numberscope@colorado.edu with steps to reproduce '
         + 'the error and the error message.'
-    window.alert(`Numberscope experienced an error.
-
-Error Message:
-${error}
-
-You might need to reload the page.
-
-${sendEmailMessage}`)
+    return errorMessage + reloadDirective + sendEmailDirective
 }


### PR DESCRIPTION
This PR:
- adds error handling via Vue's [error handler](https://vuejs.org/api/application.html#app-config-errorhandler) (see `main.ts`
- wraps the HTTP requests in `fillCache` in a try-catch
- adds an `alertMessage` utility along with docs and tests

Now the frontscope should `window.alert` an error message if an error occurs during:
- Component renders
- Event handlers
- Lifecycle hooks
- setup() function (Vue, not p5)
- Watchers
- Custom directive hooks
- Transition hooks
- HTTP requests in `fillCache` (currently the only place where we make HTTP requests)