### PR TITLE
feat: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@ the instructions therein.
 
 <hr/>
 
-/<Please provide a high-level description of your PR./>
+\<Please provide a high-level description of your PR.\>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+By submitting this PR, I am indicating to the Numberscope maintainers that I
+have read and understood the [contributing guidelines](/CONTRIBUTING.md) and
+that this PR follows those guidelines to the best of my knowledge. I have also
+read the [pull request checklist](/doc/pull-request-checklist.md) and followed
+the instructions therein.
+
+<hr/>
+
+/<Please provide a high-level description of your PR./>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 By submitting this PR, I am indicating to the Numberscope maintainers that I
-have read and understood the [contributing guidelines](/CONTRIBUTING.md) and
+have read and understood the [contributing guidelines](../CONTRIBUTING.md) and
 that this PR follows those guidelines to the best of my knowledge. I have also
-read the [pull request checklist](/doc/pull-request-checklist.md) and followed
-the instructions therein.
+read the [pull request checklist](../doc/pull-request-checklist.md) and
+followed the instructions therein.
 
 <hr/>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,10 @@
 By submitting this PR, I am indicating to the Numberscope maintainers that I
-have read and understood the [contributing guidelines](../CONTRIBUTING.md) and
-that this PR follows those guidelines to the best of my knowledge. I have also
-read the [pull request checklist](../doc/pull-request-checklist.md) and
-followed the instructions therein.
+have read and understood the
+[contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/)
+and that this PR follows those guidelines to the best of my knowledge. I have
+also read the
+[pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/)
+and followed the instructions therein.
 
 <hr/>
 


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR:

- adds `.github/pull_request_template.md`, which contains the above text and some placeholder text
- circumvents some of the issues we were having with the docsite in https://github.com/numberscope/frontscope/pull/178
- is less bureaucratic (I hope) than https://github.com/numberscope/frontscope/pull/178
- is more of a feature than documentation because it just adds the template; it doesn't add any documentation or instructions