### PR TITLE
fix(PR template): put paragraph on one line

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,4 @@
-By submitting this PR, I am indicating to the Numberscope maintainers that I
-have read and understood the
-[contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/)
-and that this PR follows those guidelines to the best of my knowledge. I have
-also read the
-[pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/)
-and followed the instructions therein.
+By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.
 
 <hr/>
 


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I
have read and understood the
[contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/)
and that this PR follows those guidelines to the best of my knowledge. I have
also read the
[pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/)
and followed the instructions therein.

<hr/>

GitHub seems to respect newlines in markdown, so when the PR template is rendered, it looks strange. (See above.) This PR puts the initial paragraph in the PR on one line so that it renders properly on GitHub.