### PR TITLE
docs: limit PR focus, make PRs small

### DIFF
--- a/doc/pull-request-checklist.md
+++ b/doc/pull-request-checklist.md
@@ -6,6 +6,11 @@ The PR submitter should:
 
 -   Please use a `snake_case` name for the branch in the PR.
 -   Please limit your PR's focus to one thing.
+-   Ideally, submit a small PR with limited functionality that can be built
+    upon instead of submitting one huge, monolithic PR. Typically, the smaller
+    the PR, the better, with the obvious caveat that the code in your PR needs
+    to work and actually do something. A small PR for a visualizer might be in
+    the ballpark of 200 lines of code.
 -   Write or supplement test(s) for the file(s) you touch in your PR.
 -   Make sure Numberscope runs properly, including former supposedly
     unmodified behaviors and newly implemented ones. In particular, run it via

--- a/doc/pull-request-checklist.md
+++ b/doc/pull-request-checklist.md
@@ -5,6 +5,7 @@
 The PR submitter should:
 
 -   Please use a `snake_case` name for the branch in the PR.
+-   Please limit your PR's focus to one thing.
 -   Write or supplement test(s) for the file(s) you touch in your PR.
 -   Make sure Numberscope runs properly, including former supposedly
     unmodified behaviors and newly implemented ones. In particular, run it via


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR adds notes to the PR checklist. One is about limiting your PR's focus to one thing. The other encourages small, incremental PRs rather than monolithic PRs.