### PR TITLE
refactor: remove all `console.log()` instances

### DIFF
--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -45,7 +45,6 @@
                 }
                 sketch.draw = function () {
                     viz.draw()
-                    console.log(sketch.frameCount)
                     if (sketch.frameCount >= 50) {
                         sketch.noLoop()
                     }

--- a/src/components/SequenceMenu.vue
+++ b/src/components/SequenceMenu.vue
@@ -94,7 +94,6 @@
                 isInstance: boolean,
                 activeSeq: SequenceExportModule
             ) {
-                console.log(activeSeq)
                 if (isInstance) {
                     // instances are already constructed
                     this.liveSequence =

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -109,7 +109,6 @@ implemented visualizers.
                 seq: SequenceInterface
                 viz: VisualizerInterface
             }) {
-                console.log(seqVizBundle)
                 this.activeSeq = seqVizBundle.seq
                 this.activeViz = seqVizBundle.viz
                 this.drawingActive = true

--- a/src/visualizers/VisualizerShiftCompare.ts
+++ b/src/visualizers/VisualizerShiftCompare.ts
@@ -72,16 +72,6 @@ class VizShiftCompare
         // Ensure mouse coordinates are sane.
         // Mouse coordinates look they're floats by default.
         const d = this.sketch.pixelDensity()
-        const mx = this.clip(
-            Math.round(this.sketch.mouseX),
-            0,
-            this.sketch.width
-        )
-        const my = this.clip(
-            Math.round(this.sketch.mouseY),
-            0,
-            this.sketch.height
-        )
         if (this.sketch.key == 'ArrowUp') {
             this.mod += 1n
             this.sketch.key = ''
@@ -90,8 +80,6 @@ class VizShiftCompare
             this.mod -= 1n
             this.sketch.key = ''
             this.refreshParams()
-        } else if (this.sketch.key == 'ArrowRight') {
-            console.log(console.log('MX: ' + mx + ' MY: ' + my))
         }
         // since settings.mod can be any of string | number | bool,
         // assign it here explictly to a number, to avoid type errors


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR removes all instances of `console.log()`. Resolves https://github.com/numberscope/frontscope/issues/45.
