### PR TITLE
docs(PR checklist): reviewer updates contributors

### DIFF
--- a/doc/pull-request-checklist.md
+++ b/doc/pull-request-checklist.md
@@ -18,6 +18,9 @@ The PR submitter should:
     log messages from Numberscope code, warnings, or errors.
 -   Read over the reviewer checklist and try to make sure in advance that your
     code is going to proceed as smoothly through the review as possible.
+-   Optinally, update the
+    ["Contributors" section of the "About" document](../about.md#contributors)
+    to include your name if your PR is going to be merged.
 
 ## For PR reviewers
 
@@ -35,3 +38,6 @@ The PR submitter should:
     have time for, definitely including but not limited to the ones nominally
     affected by the PR. This should be done in `npm run preview` mode after a
     successful build.
+-   Remind the submitter that they can update the
+    ["Contributors" section of the "About" document](../about.md#contributors)
+    to include their name if the PR is going to be merged.

--- a/doc/pull-request-checklist.md
+++ b/doc/pull-request-checklist.md
@@ -38,4 +38,4 @@ The PR submitter should:
 -   At the end of the review process, before merging, add a commit to update
     the
     ["Contributors" section of the "About" document](../about.md#contributors)
-    to include the submitter's name.
+    to include the submitter's name, if it is not already present.

--- a/doc/pull-request-checklist.md
+++ b/doc/pull-request-checklist.md
@@ -18,9 +18,6 @@ The PR submitter should:
     log messages from Numberscope code, warnings, or errors.
 -   Read over the reviewer checklist and try to make sure in advance that your
     code is going to proceed as smoothly through the review as possible.
--   Optinally, update the
-    ["Contributors" section of the "About" document](../about.md#contributors)
-    to include your name if your PR is going to be merged.
 
 ## For PR reviewers
 
@@ -38,6 +35,7 @@ The PR submitter should:
     have time for, definitely including but not limited to the ones nominally
     affected by the PR. This should be done in `npm run preview` mode after a
     successful build.
--   Remind the submitter that they can update the
+-   At the end of the review process, before merging, add a commit to update
+    the
     ["Contributors" section of the "About" document](../about.md#contributors)
-    to include their name if the PR is going to be merged.
+    to include the submitter's name.


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Adds notes about optionally updating the list of contributors at the end of your PR review.
