### PR TITLE
refactor: give visualizers access to canvas, create p5 visualizer class

### DIFF
--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -6,7 +6,7 @@
                 <p class="card-text">
                     This is a bundle of {{ seq.name + ' + ' + viz.name }}.
                 </p>
-                <div :id="cid"></div>
+                <div class="canvasContainer" :id="cid"></div>
                 <a
                     v-on:click="$emit('drawBundle', {seq: seq, viz: viz})"
                     href="#"
@@ -36,7 +36,12 @@
                 this.cid
             ) as HTMLElement
             this.seq.initialize()
-            this.viz.initialize(canvasContainer, this.seq)
+            this.viz.initialize(
+                canvasContainer,
+                this.seq,
+                canvasContainer.offsetWidth,
+                canvasContainer.offsetHeight
+            )
             this.viz.setup()
             this.viz.draw()
         },
@@ -60,5 +65,9 @@
     .card {
         margin: 1em;
         min-height: 250px;
+    }
+    .canvasContainer {
+        width: 100px;
+        height: 100px;
     }
 </style>

--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -32,8 +32,11 @@
     export default defineComponent({
         name: 'BundleCard',
         mounted() {
+            const canvasContainer = document.getElementById(
+                this.cid
+            ) as HTMLElement
             this.seq.initialize()
-            this.viz.initialize(this.viz.sketch, this.seq)
+            this.viz.initialize(canvasContainer, this.seq)
             this.viz.setup()
             this.viz.draw()
         },

--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -26,32 +26,16 @@
 
 <script lang="ts">
     import {defineComponent} from 'vue'
-    import p5 from 'p5'
     // we need a unique id for each canvas
     // see https://github.com/vuejs/vue/issues/5886#issuecomment-308647738
     let cid_count = 0
     export default defineComponent({
         name: 'BundleCard',
         mounted() {
-            const seq = this.seq
-            seq.initialize()
-            const viz = this.viz
-            const thumb = new p5(function (sketch) {
-                viz.initialize(sketch, seq)
-                sketch.setup = function () {
-                    sketch.createCanvas(200, 200)
-                    sketch.background('white')
-                    viz.setup()
-                }
-                sketch.draw = function () {
-                    viz.draw()
-                    if (sketch.frameCount >= 50) {
-                        sketch.noLoop()
-                    }
-                }
-            }, document.getElementById(this.cid) as HTMLElement)
-            thumb.setup()
-            thumb.draw()
+            this.seq.initialize()
+            this.viz.initialize(this.viz.sketch, this.seq)
+            this.viz.setup()
+            this.viz.draw()
         },
         methods: {},
         props: {

--- a/src/components/CanvasArea.vue
+++ b/src/components/CanvasArea.vue
@@ -16,7 +16,7 @@
     import type {PropType} from 'vue'
     import type {VisualizerInterface} from '../visualizers/VisualizerInterface'
     import type {SequenceInterface} from '../sequences/SequenceInterface'
-    import p5 from 'p5'
+    import type p5 from 'p5'
     import StopDrawingButton from './StopDrawingButton.vue'
     export default defineComponent({
         name: 'CanvasArea',
@@ -43,19 +43,9 @@
             const activeSeq = this.activeSeq
             activeSeq.initialize()
             const activeViz = this.activeViz
-            this.drawing = new p5(function (sketch) {
-                activeViz.initialize(sketch, activeSeq)
-                sketch.setup = function () {
-                    sketch.createCanvas(800, 800)
-                    sketch.background('white')
-                    activeViz.setup()
-                }
-                sketch.draw = function () {
-                    activeViz.draw()
-                }
-            }, document.getElementById('p5-goes-here') as HTMLElement)
-            this.drawing.setup()
-            this.drawing.draw()
+            activeViz.initialize(this.activeViz.sketch, activeSeq)
+            activeViz.setup()
+            activeViz.draw()
         },
         data: function () {
             return {drawing: {} as p5} // To get correct type

--- a/src/components/CanvasArea.vue
+++ b/src/components/CanvasArea.vue
@@ -35,13 +35,15 @@
         },
         methods: {
             closeCanvas: function (): void {
-                this.activeViz.sketch.noLoop()
                 this.$emit('closeCanvas')
             },
         },
         mounted: function (): void {
+            const canvasContainer = document.getElementById(
+                'p5-goes-here'
+            ) as HTMLElement
             this.activeSeq.initialize()
-            this.activeViz.initialize(this.activeViz.sketch, this.activeSeq)
+            this.activeViz.initialize(canvasContainer, this.activeSeq)
             this.activeViz.setup()
             this.activeViz.draw()
         },

--- a/src/components/CanvasArea.vue
+++ b/src/components/CanvasArea.vue
@@ -35,17 +35,15 @@
         },
         methods: {
             closeCanvas: function (): void {
-                this.drawing.noLoop()
+                this.activeViz.sketch.noLoop()
                 this.$emit('closeCanvas')
             },
         },
         mounted: function (): void {
-            const activeSeq = this.activeSeq
-            activeSeq.initialize()
-            const activeViz = this.activeViz
-            activeViz.initialize(this.activeViz.sketch, activeSeq)
-            activeViz.setup()
-            activeViz.draw()
+            this.activeSeq.initialize()
+            this.activeViz.initialize(this.activeViz.sketch, this.activeSeq)
+            this.activeViz.setup()
+            this.activeViz.draw()
         },
         data: function () {
             return {drawing: {} as p5} // To get correct type

--- a/src/components/CanvasArea.vue
+++ b/src/components/CanvasArea.vue
@@ -6,7 +6,7 @@
             </div>
         </div>
         <div class="col-sm-10">
-            <div id="p5-goes-here"></div>
+            <div id="canvasContainer"></div>
         </div>
     </div>
 </template>
@@ -40,10 +40,18 @@
         },
         mounted: function (): void {
             const canvasContainer = document.getElementById(
-                'p5-goes-here'
+                'canvasContainer'
             ) as HTMLElement
             this.activeSeq.initialize()
-            this.activeViz.initialize(canvasContainer, this.activeSeq)
+            this.activeViz.initialize(
+                canvasContainer,
+                this.activeSeq,
+                canvasContainer.offsetWidth,
+                canvasContainer.offsetHeight
+            )
+
+            // These two methods are (presumably) only needed by p5
+            // visualizers.
             this.activeViz.setup()
             this.activeViz.draw()
         },
@@ -53,4 +61,9 @@
     })
 </script>
 
-<style scoped></style>
+<style scoped>
+    #canvasContainer {
+        width: 800px;
+        height: 800px;
+    }
+</style>

--- a/src/shared/dummyp5.ts
+++ b/src/shared/dummyp5.ts
@@ -1,0 +1,6 @@
+import p5 from 'p5'
+
+// We create a dummy p5 object because we want the sketch data member in the
+// VisualizerP5 class to have the correct type, and we don't want to guard
+// against it being undefined.
+export const dummySketch = new p5(sketch => sketch)

--- a/src/visualizers/Chaos.ts
+++ b/src/visualizers/Chaos.ts
@@ -1,7 +1,7 @@
 import p5 from 'p5'
 import {modulo} from '../shared/math'
-import {VisualizerDefault} from './VisualizerDefault'
 import {VisualizerExportModule} from './VisualizerInterface'
+import {VisualizerP5} from './VisualizerP5'
 
 /** md
 # Chaos Visualizer
@@ -43,7 +43,7 @@ enum ColorStyle {
 // or shrink over time;
 // circles fade to the outside
 
-class Chaos extends VisualizerDefault {
+class Chaos extends VisualizerP5 {
     name = 'Chaos'
     corners = 4
     frac = 0.5

--- a/src/visualizers/Differences.ts
+++ b/src/visualizers/Differences.ts
@@ -59,8 +59,13 @@ class Differences extends VisualizerP5 {
         return status
     }
 
-    initialize(canvasContainer: HTMLElement, seq: SequenceInterface): void {
-        super.initialize(canvasContainer, seq)
+    initialize(
+        canvasContainer: HTMLElement,
+        seq: SequenceInterface,
+        maxWidth: number,
+        maxHeight: number
+    ) {
+        super.initialize(canvasContainer, seq, maxWidth, maxHeight)
         if (!this.levels) {
             this.levels = this.n
             this.refreshParams()

--- a/src/visualizers/Differences.ts
+++ b/src/visualizers/Differences.ts
@@ -1,7 +1,6 @@
 import type {SequenceInterface} from '../sequences/SequenceInterface'
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
-import type p5 from 'p5'
-import {VisualizerDefault} from './VisualizerDefault'
+import {VisualizerP5} from './VisualizerP5'
 
 const min = Math.min
 
@@ -18,7 +17,7 @@ between the terms in the row above, for as many rows as you like.
 ## Parameters
 **/
 
-class Differences extends VisualizerDefault {
+class Differences extends VisualizerP5 {
     name = 'Differences'
 
     n = 20
@@ -60,8 +59,8 @@ class Differences extends VisualizerDefault {
         return status
     }
 
-    initialize(sketch: p5, seq: SequenceInterface): void {
-        super.initialize(sketch, seq)
+    initialize(canvasContainer: HTMLElement, seq: SequenceInterface): void {
+        super.initialize(canvasContainer, seq)
         if (!this.levels) {
             this.levels = this.n
             this.refreshParams()

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -1,9 +1,9 @@
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
-import {VisualizerDefault} from '@/visualizers/VisualizerDefault'
 import {bigabs, floorSqrt, modulo} from '@/shared/math'
 import type {ParamInterface} from '@/shared/Paramable'
 import type {Factorization} from '@/sequences/SequenceInterface'
 import simpleFactor from '@/sequences/simpleFactor'
+import {VisualizerP5} from './VisualizerP5'
 
 /** md
 # Grid Visualizer
@@ -412,7 +412,7 @@ const propertyIndicatorFunction: {
     Semi_Prime: isSemiPrime,
 }
 
-class Grid extends VisualizerDefault {
+class Grid extends VisualizerP5 {
     name = 'Grid'
 
     // Grid variables

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -1,5 +1,5 @@
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
-import {VisualizerDefault} from './VisualizerDefault'
+import {VisualizerP5} from './VisualizerP5'
 
 /** md
 # Factor Histogram
@@ -17,7 +17,7 @@ Designed by Devlin Costello.
 ## Parameters
 **/
 
-class FactorHistogramVisualizer extends VisualizerDefault {
+class FactorHistogramVisualizer extends VisualizerP5 {
     name = 'Factor Histogram'
 
     binSize = 1

--- a/src/visualizers/ModFill.ts
+++ b/src/visualizers/ModFill.ts
@@ -1,8 +1,8 @@
 import {modulo} from '../shared/math'
 import type {SequenceInterface} from '../sequences/SequenceInterface'
-import {VisualizerDefault} from '../visualizers/VisualizerDefault'
 import type {VisualizerInterface} from '@/visualizers/VisualizerInterface'
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
+import {VisualizerP5} from './VisualizerP5'
 
 /** md
 # Mod Fill Visualizer
@@ -18,7 +18,7 @@ occur by watching the order the cells are filled in as the diagram is drawn.
 ## Parameters
 **/
 
-class VizModFill extends VisualizerDefault implements VisualizerInterface {
+class VizModFill extends VisualizerP5 implements VisualizerInterface {
     name = 'Mod Fill'
     modDimension = 10n
     params = {

--- a/src/visualizers/MouseClick.ts
+++ b/src/visualizers/MouseClick.ts
@@ -20,8 +20,13 @@ class MouseClick extends VisualizerP5 {
         return super.checkParameters()
     }
 
-    initialize(canvasContainer: HTMLElement, seq: SequenceInterface) {
-        super.initialize(canvasContainer, seq)
+    initialize(
+        canvasContainer: HTMLElement,
+        seq: SequenceInterface,
+        maxWidth: number,
+        maxHeight: number
+    ) {
+        super.initialize(canvasContainer, seq, maxWidth, maxHeight)
     }
 
     setup() {

--- a/src/visualizers/MouseClick.ts
+++ b/src/visualizers/MouseClick.ts
@@ -27,8 +27,6 @@ class MouseClick extends VisualizerDefault {
 
     setup() {
         super.setup()
-        console.log('in mouse click setup')
-        console.log(this.canvas)
         this.canvas.mouseClicked(() => {
             this.sketch.text(this.onClickMessage, 50, 50)
         })

--- a/src/visualizers/MouseClick.ts
+++ b/src/visualizers/MouseClick.ts
@@ -1,0 +1,46 @@
+import {VisualizerDefault} from './VisualizerDefault'
+import type {ValidationStatus} from '../shared/ValidationStatus'
+import type {SequenceInterface} from '../sequences/SequenceInterface'
+import type p5 from 'p5'
+import {VisualizerExportModule} from './VisualizerInterface'
+
+class MouseClick extends VisualizerDefault {
+    name = 'Mouse Click'
+    onClickMessage = 'Huzzah! The mouse was clicked!'
+
+    params = {
+        onClickMessage: {
+            value: this.onClickMessage,
+            forceType: 'string',
+            displayName: 'The message to display when the canvas is clicked',
+            required: true,
+        },
+    }
+
+    checkParameters(): ValidationStatus {
+        return super.checkParameters()
+    }
+
+    initialize(sketch: p5, seq: SequenceInterface) {
+        super.initialize(sketch, seq)
+    }
+
+    setup() {
+        super.setup()
+        console.log('in mouse click setup')
+        console.log(this.canvas)
+        this.canvas.mouseClicked(() => {
+            this.sketch.text(this.onClickMessage, 50, 50)
+        })
+    }
+
+    draw() {
+        this.sketch.text('Mouse Click Visualizer', 100, 100)
+    }
+}
+
+export const exportModule = new VisualizerExportModule(
+    'Mouse Click',
+    MouseClick,
+    'Displays a message when you click the canvas.'
+)

--- a/src/visualizers/MouseClick.ts
+++ b/src/visualizers/MouseClick.ts
@@ -1,10 +1,9 @@
-import {VisualizerDefault} from './VisualizerDefault'
 import type {ValidationStatus} from '../shared/ValidationStatus'
 import type {SequenceInterface} from '../sequences/SequenceInterface'
-import type p5 from 'p5'
 import {VisualizerExportModule} from './VisualizerInterface'
+import {VisualizerP5} from './VisualizerP5'
 
-class MouseClick extends VisualizerDefault {
+class MouseClick extends VisualizerP5 {
     name = 'Mouse Click'
     onClickMessage = 'Huzzah! The mouse was clicked!'
 
@@ -21,8 +20,8 @@ class MouseClick extends VisualizerDefault {
         return super.checkParameters()
     }
 
-    initialize(sketch: p5, seq: SequenceInterface) {
-        super.initialize(sketch, seq)
+    initialize(canvasContainer: HTMLElement, seq: SequenceInterface) {
+        super.initialize(canvasContainer, seq)
     }
 
     setup() {

--- a/src/visualizers/ShiftCompare.ts
+++ b/src/visualizers/ShiftCompare.ts
@@ -1,8 +1,8 @@
 import p5 from 'p5'
 import {modulo} from '../shared/math'
-import {VisualizerDefault} from './VisualizerDefault'
 import type {VisualizerInterface} from '@/visualizers/VisualizerInterface'
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
+import {VisualizerP5} from './VisualizerP5'
 
 /** md
 # Shift Compare Visualizer
@@ -20,10 +20,7 @@ modulus). The pixel is colored black otherwise.
 
 // CAUTION: This is unstable with some sequences
 // Using it may crash your browser
-class VizShiftCompare
-    extends VisualizerDefault
-    implements VisualizerInterface
-{
+class VizShiftCompare extends VisualizerP5 implements VisualizerInterface {
     name = 'Shift Compare'
     private img: p5.Image = new p5.Image(1, 1) // just a dummy
     mod = 2n

--- a/src/visualizers/ShowFactors.ts
+++ b/src/visualizers/ShowFactors.ts
@@ -1,5 +1,5 @@
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
-import {VisualizerDefault} from './VisualizerDefault'
+import {VisualizerP5} from './VisualizerP5'
 
 /** md
 # Show Factors Visualizer
@@ -12,7 +12,7 @@ the sequence, and below each term, its prime factors.
 ## Parameters
 **/
 
-class ShowFactors extends VisualizerDefault {
+class ShowFactors extends VisualizerP5 {
     name = 'Show Factors'
 
     start = 1

--- a/src/visualizers/Turtle.ts
+++ b/src/visualizers/Turtle.ts
@@ -106,8 +106,13 @@ class Turtle extends VisualizerP5 implements VisualizerInterface {
     private X = 0
     private Y = 0
 
-    initialize(canvasContainer: HTMLElement, seq: SequenceInterface) {
-        super.initialize(canvasContainer, seq)
+    initialize(
+        canvasContainer: HTMLElement,
+        seq: SequenceInterface,
+        maxWidth: number,
+        maxHeight: number
+    ) {
+        super.initialize(canvasContainer, seq, maxWidth, maxHeight)
 
         this.currentIndex = seq.first
         this.orientation = 0

--- a/src/visualizers/Turtle.ts
+++ b/src/visualizers/Turtle.ts
@@ -1,8 +1,8 @@
 import p5 from 'p5'
-import {VisualizerDefault} from './VisualizerDefault'
 import type {VisualizerInterface} from '@/visualizers/VisualizerInterface'
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
 import type {SequenceInterface} from '../sequences/SequenceInterface'
+import {VisualizerP5} from './VisualizerP5'
 
 /** md
 # Turtle Visualizer
@@ -18,7 +18,7 @@ straight segment. It displays the resulting polygonal path.
 
 // Turtle needs work
 // Throwing the same error on previous Numberscope website
-class Turtle extends VisualizerDefault implements VisualizerInterface {
+class Turtle extends VisualizerP5 implements VisualizerInterface {
     name = 'Turtle'
     private rotMap = new Map<string, number>()
     domain = [0n, 1n, 2n, 3n, 4n]
@@ -106,9 +106,8 @@ class Turtle extends VisualizerDefault implements VisualizerInterface {
     private X = 0
     private Y = 0
 
-    initialize(sketch: p5, seq: SequenceInterface) {
-        this.sketch = sketch
-        this.seq = seq
+    initialize(canvasContainer: HTMLElement, seq: SequenceInterface) {
+        super.initialize(canvasContainer, seq)
 
         this.currentIndex = seq.first
         this.orientation = 0
@@ -121,8 +120,6 @@ class Turtle extends VisualizerDefault implements VisualizerInterface {
                 (Math.PI / 180) * this.range[i]
             )
         }
-
-        this.ready = true
     }
 
     checkParameters() {

--- a/src/visualizers/VisualizerDefault.ts
+++ b/src/visualizers/VisualizerDefault.ts
@@ -11,13 +11,22 @@ export class VisualizerDefault
     description = 'Base class for implementing Visualizers'
     ready = false
     seq: SequenceInterface = new SequenceDefault(0)
+    maxWidth = 0
+    maxHeight = 0
     /***
       Sets the sketch and the sequence to draw with
       This is also where you would generate any settings or
       draw functions if needed
       */
-    initialize(canvasContainer: HTMLElement, seq: SequenceInterface): void {
+    initialize(
+        canvasContainer: HTMLElement,
+        seq: SequenceInterface,
+        maxWidth: number,
+        maxHeight: number
+    ): void {
         if (this.isValid) {
+            this.maxWidth = maxWidth
+            this.maxHeight = maxHeight
             this.seq = seq
             this.ready = true
         } else {

--- a/src/visualizers/VisualizerDefault.ts
+++ b/src/visualizers/VisualizerDefault.ts
@@ -39,9 +39,6 @@ export class VisualizerDefault
         this.sketch.background('white')
     }
     draw(): void {
-        if (this.sketch.frameCount >= 50) {
-            this.sketch.noLoop()
-        }
         return
     }
 }

--- a/src/visualizers/VisualizerDefault.ts
+++ b/src/visualizers/VisualizerDefault.ts
@@ -36,9 +36,7 @@ export class VisualizerDefault
     }
     setup(): void {
         this.canvas = this.sketch.createCanvas(800, 800)
-        console.log(this.canvas)
         this.sketch.background('white')
-        console.log('default setup done')
     }
     draw(): void {
         if (this.sketch.frameCount >= 50) {

--- a/src/visualizers/VisualizerDefault.ts
+++ b/src/visualizers/VisualizerDefault.ts
@@ -2,7 +2,6 @@ import type {VisualizerInterface} from './VisualizerInterface'
 import {Paramable} from '../shared/Paramable'
 import type {SequenceInterface} from '../sequences/SequenceInterface'
 import {SequenceDefault} from '../sequences/SequenceDefault'
-import p5 from 'p5'
 
 export class VisualizerDefault
     extends Paramable
@@ -11,21 +10,15 @@ export class VisualizerDefault
     name = 'Default Visualizer'
     description = 'Base class for implementing Visualizers'
     ready = false
-    sketch: p5 = new p5(sketch => {
-        return sketch
-    })
-    canvas: p5.Renderer | Record<string, never> = {}
     seq: SequenceInterface = new SequenceDefault(0)
     /***
       Sets the sketch and the sequence to draw with
       This is also where you would generate any settings or
       draw functions if needed
       */
-    initialize(sketch: p5, seq: SequenceInterface): void {
+    initialize(canvasContainer: HTMLElement, seq: SequenceInterface): void {
         if (this.isValid) {
-            this.sketch = sketch
             this.seq = seq
-
             this.ready = true
         } else {
             throw (
@@ -34,11 +27,12 @@ export class VisualizerDefault
             )
         }
     }
-    setup(): void {
-        this.canvas = this.sketch.createCanvas(800, 800)
-        this.sketch.background('white')
+
+    setup() {
+        return
     }
-    draw(): void {
+
+    draw() {
         return
     }
 }

--- a/src/visualizers/VisualizerDefault.ts
+++ b/src/visualizers/VisualizerDefault.ts
@@ -14,6 +14,7 @@ export class VisualizerDefault
     sketch: p5 = new p5(sketch => {
         return sketch
     })
+    canvas: p5.Renderer | Record<string, never> = {}
     seq: SequenceInterface = new SequenceDefault(0)
     /***
       Sets the sketch and the sequence to draw with
@@ -34,9 +35,15 @@ export class VisualizerDefault
         }
     }
     setup(): void {
-        return
+        this.canvas = this.sketch.createCanvas(800, 800)
+        console.log(this.canvas)
+        this.sketch.background('white')
+        console.log('default setup done')
     }
     draw(): void {
+        if (this.sketch.frameCount >= 50) {
+            this.sketch.noLoop()
+        }
         return
     }
 }

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -1,6 +1,5 @@
 import type {SequenceInterface} from '../sequences/SequenceInterface'
 import type {ParamableInterface} from '../shared/Paramable'
-import type p5 from 'p5'
 
 interface VisualizerConstructor {
     new (): VisualizerInterface
@@ -28,22 +27,15 @@ export interface VisualizerInterface extends ParamableInterface {
      */
     seq: SequenceInterface
     /**
-     * A p5 sketch instance.
-     */
-    sketch: p5
-    /**
      * Initialize is simply applying the validated configuration params to the
      * visualizer to prepare it to draw.
-     * @param sketch The p5 instance the visualizer will draw on
+     * @param canvasContainer The HTML element that the visualizer is
+     *                        given to create a canvas in
      * @param seq The Sequence object supplying sequence values
      */
-    initialize(sketch: p5, seq: SequenceInterface): void
-    /**
-     * Sets up the p5 canvas.
-     */
+    initialize(canvasContainer: HTMLElement, seq: SequenceInterface): void
+
     setup(): void
-    /**
-     * Draws the sequence through the visualizer into the p5 canvas.
-     */
+
     draw(): void
 }

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -9,7 +9,6 @@ export class VisualizerExportModule {
     name: string
     description: string
     visualizer: VisualizerConstructor
-
     constructor(
         name: string,
         viz: VisualizerConstructor,
@@ -27,13 +26,30 @@ export interface VisualizerInterface extends ParamableInterface {
      */
     seq: SequenceInterface
     /**
+     * The maximum width the visualizer is allowed to occupy on the screen
+     * in pixels(?).
+     */
+    maxWidth: number
+    /**
+     * The maximum height the visualizer is allowed to occupy on the screen
+     * in pixels(?).
+     */
+    maxHeight: number
+    /**
      * Initialize is simply applying the validated configuration params to the
      * visualizer to prepare it to draw.
      * @param canvasContainer The HTML element that the visualizer is
      *                        given to create a canvas in
      * @param seq The Sequence object supplying sequence values
+     * @param maxWidth The maximum width for the visualizer in pixels(?)
+     * @param maxHeight The maximum height for the visualizer in pixels(?)
      */
-    initialize(canvasContainer: HTMLElement, seq: SequenceInterface): void
+    initialize(
+        canvasContainer: HTMLElement,
+        seq: SequenceInterface,
+        maxWidth: number,
+        maxHeight: number
+    ): void
 
     setup(): void
 

--- a/src/visualizers/VisualizerP5.ts
+++ b/src/visualizers/VisualizerP5.ts
@@ -1,0 +1,25 @@
+import {VisualizerDefault} from './VisualizerDefault'
+import p5 from 'p5'
+import type {SequenceInterface} from '../sequences/SequenceInterface'
+
+export class VisualizerP5 extends VisualizerDefault {
+    name = 'p5 Visualizer'
+    description = 'Base class for implementing p5 visualizers'
+
+    // We initialize the sketch variable to be a dummy p5 object because
+    // we want it to have the correct type, and we don't want to guard
+    // against it being undefined.
+    sketch: p5 = new p5(sketch => sketch)
+    canvas: p5.Renderer | Record<string, never> = {}
+    initialize(canvasContainer: HTMLElement, seq: SequenceInterface) {
+        super.initialize(canvasContainer, seq)
+        this.sketch = new p5(sketch => sketch, canvasContainer)
+    }
+    setup() {
+        this.canvas = this.sketch.createCanvas(800, 800)
+        this.sketch.background('white')
+    }
+    draw() {
+        return
+    }
+}

--- a/src/visualizers/VisualizerP5.ts
+++ b/src/visualizers/VisualizerP5.ts
@@ -1,15 +1,12 @@
 import {VisualizerDefault} from './VisualizerDefault'
 import p5 from 'p5'
 import type {SequenceInterface} from '../sequences/SequenceInterface'
+import {dummySketch} from '../shared/dummyp5'
 
 export class VisualizerP5 extends VisualizerDefault {
     name = 'p5 Visualizer'
     description = 'Base class for implementing p5 visualizers'
-
-    // We initialize the sketch variable to be a dummy p5 object because
-    // we want it to have the correct type, and we don't want to guard
-    // against it being undefined.
-    sketch: p5 = new p5(sketch => sketch)
+    sketch: p5 = dummySketch
     canvas: p5.Renderer | Record<string, never> = {}
     initialize(
         canvasContainer: HTMLElement,

--- a/src/visualizers/VisualizerP5.ts
+++ b/src/visualizers/VisualizerP5.ts
@@ -11,12 +11,17 @@ export class VisualizerP5 extends VisualizerDefault {
     // against it being undefined.
     sketch: p5 = new p5(sketch => sketch)
     canvas: p5.Renderer | Record<string, never> = {}
-    initialize(canvasContainer: HTMLElement, seq: SequenceInterface) {
-        super.initialize(canvasContainer, seq)
+    initialize(
+        canvasContainer: HTMLElement,
+        seq: SequenceInterface,
+        maxWidth: number,
+        maxHeight: number
+    ) {
+        super.initialize(canvasContainer, seq, maxWidth, maxHeight)
         this.sketch = new p5(sketch => sketch, canvasContainer)
     }
     setup() {
-        this.canvas = this.sketch.createCanvas(800, 800)
+        this.canvas = this.sketch.createCanvas(this.maxWidth, this.maxHeight)
         this.sketch.background('white')
     }
     draw() {


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR is for https://github.com/numberscope/frontscope/issues/120. I refactored `VisualizerInterface`, `VisualizerDefault`, and created `VisualizerP5` in an effort to provide visualizers access to their canvas, and move us away from visualizers being tied to p5. I also made changes to `CanvasArea` and `BundleCard` that reflect the changes made to the visualizer modules. I made a proof-of-concept visualizer, `MouseClick`, to demonstrate how we can use p5's `mouseClicked` method.

I am green when it comes to object-oriented programming. Please tell me what needs to be improved and why it needs improvement.