### PR TITLE
fix: Reduce error alerts by increasing caching tolerance

### DIFF
--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -27,6 +27,7 @@
 <script lang="ts">
     import {defineComponent} from 'vue'
     import p5 from 'p5'
+    import {CachingError} from '../sequences/Cached'
     // we need a unique id for each canvas
     // see https://github.com/vuejs/vue/issues/5886#issuecomment-308647738
     let cid_count = 0
@@ -44,7 +45,17 @@
                     viz.setup()
                 }
                 sketch.draw = function () {
-                    viz.draw()
+                    try {
+                        viz.draw()
+                    } catch (e) {
+                        if (e instanceof CachingError) {
+                            sketch.cursor('progress')
+                            return
+                        } else {
+                            throw e
+                        }
+                    }
+                    sketch.cursor(sketch.ARROW)
                     if (sketch.frameCount >= 50) {
                         sketch.noLoop()
                     }

--- a/src/components/CanvasArea.vue
+++ b/src/components/CanvasArea.vue
@@ -16,6 +16,7 @@
     import type {PropType} from 'vue'
     import type {VisualizerInterface} from '../visualizers/VisualizerInterface'
     import type {SequenceInterface} from '../sequences/SequenceInterface'
+    import {CachingError} from '../sequences/Cached'
     import p5 from 'p5'
     import StopDrawingButton from './StopDrawingButton.vue'
     export default defineComponent({
@@ -51,7 +52,17 @@
                     activeViz.setup()
                 }
                 sketch.draw = function () {
-                    activeViz.draw()
+                    try {
+                        activeViz.draw()
+                    } catch (e) {
+                        if (e instanceof CachingError) {
+                            sketch.cursor('progress')
+                            return
+                        } else {
+                            throw e
+                        }
+                    }
+                    sketch.cursor(sketch.ARROW)
                 }
             }, document.getElementById('p5-goes-here') as HTMLElement)
             this.drawing.setup()

--- a/src/sequences/OEIS.ts
+++ b/src/sequences/OEIS.ts
@@ -44,7 +44,10 @@ export default class OEIS extends Cached {
         super(sequenceID) // Don't know the index range yet, will fill in later
     }
 
-    async fillCache(): Promise<void> {
+    /* Unlike the base Cached sequence class, we grab the entire sequence
+       at once.
+    */
+    async fillValueCache(): Promise<void> {
         // Catch HTTP errors. (This function has multiple HTTP requests.)
         try {
             // import.meta.env is basically your configuration.
@@ -75,41 +78,52 @@ export default class OEIS extends Cached {
             */
                 this.first = 0
                 this.last = -1
-            } else {
-                // OK, now get the factors
-                const factorUrl =
-                    urlPrefix
-                    + `get_oeis_factors/${this.oeisId}/${this.cacheBlock}`
-                const factorResponse = await axios.get(factorUrl)
-                for (const k in factorResponse.data.factors) {
-                    const index = Number(k)
-                    if (index < this.first || index > this.last) continue
-                    const factors = factorResponse.data.factors[k]
-                    if (factors === 'no_fac') {
-                        this.factorCache[index] = null
+                this.cacheBlock = 0
+            }
+            this.lastValueCached = this.last
+            this.cachingValuesTo = this.last
+        } catch (e) {
+            window.alert(alertMessage(e))
+        }
+    }
+
+    async fillFactorCache(): Promise<void> {
+        // Short-circuit if sequence is empty
+        if (this.cacheBlock < 1) return
+        try {
+            const urlPrefix = `${import.meta.env.VITE_BACKSCOPE_URL}/api/`
+            const factorUrl =
+                urlPrefix
+                + `get_oeis_factors/${this.oeisId}/${this.cacheBlock}`
+            const factorResponse = await axios.get(factorUrl)
+            for (const k in factorResponse.data.factors) {
+                const index = Number(k)
+                if (index < this.first || index > this.last) continue
+                const factors = factorResponse.data.factors[k]
+                if (factors === 'no_fac') {
+                    this.factorCache[index] = null
+                } else {
+                    // Sadly, we have to parse the factors as a _string_
+                    // ourselves:
+                    if (factors === '[]') {
+                        this.factorCache[index] = []
                     } else {
-                        // Sadly, we have to parse the factors as a _string_
-                        // ourselves:
-                        if (factors === '[]') {
-                            this.factorCache[index] = []
-                        } else {
-                            // Lop off the initial '[[' and final ']]'
-                            const internals = factors.slice(2, -2)
-                            // That leaves '],[' separating the pairs
-                            const entries = internals.split('],[')
-                            this.factorCache[index] = entries.map(
-                                (pair: string) => {
-                                    // And each pair is comma-separated
-                                    const [base, power] = pair.split(',', 2)
-                                    return [BigInt(base), BigInt(power)]
-                                }
-                            )
-                        }
+                        // Lop off the initial '[[' and final ']]'
+                        const internals = factors.slice(2, -2)
+                        // That leaves '],[' separating the pairs
+                        const entries = internals.split('],[')
+                        this.factorCache[index] = entries.map(
+                            (pair: string) => {
+                                // And each pair is comma-separated
+                                const [base, power] = pair.split(',', 2)
+                                return [BigInt(base), BigInt(power)]
+                            }
+                        )
                     }
                 }
             }
-            this.lastCached = this.last
-            this.cachingTo = this.last
+            this.lastFactorCached = this.last
+            this.cachingFactorsTo = this.last
         } catch (e) {
             window.alert(alertMessage(e))
         }


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Before this PR, all cached sequences loaded factorizations into the cache in strict lockstep with values. But many visualizers do not use the factorizations, and they require extra computations and/or http requests that can be wasteful if the results will not be used. This PR decouples the two caches, so that values can be cached without factorizations (although not vice versa, since you may need the values to obtain their factorizations).

This created a new issue: since the factorizations are not cached until their first request, every single OEIS sequence was reporting caching errors in the ShowFactors visualizer. That was because the ShowFactors simply loops over every value and gets its factorization. The first call to getFactors was triggering the cache fill, but for OEIS sequences the cache fill is _asynchronous_, so it returns immediately without having completed the operation. That meant the second call to getFactors was _guaranteed_ to trigger an error that caching was in progress, since it completely certain was in fact in progress at that point.

The solution to this conundrum was to take advantage of p5's display loop. In the draw method, such caching errors are caught, and trigger a "progress spinner" cursor to appear. But of course p5 then simply gets to the next frame (after a delay dependent on the frame rate) and tries to access the cached values again. After a (typically very small) number of frames, the cache fill has completed, and the sequence is able to supply the factorizations without any CachingErrors. At this point, the draw() method clears the cursor and all seems well.

Running this PR in the frontend with https://github.com/numberscope/backscope/pull/67 in a local backend is producing really robust visualizer results for brand-new OEIS sequences for me. Hopefully the same will prove true in the review.

Resolves #260