### PR TITLE
Grid modify sequence capability

### DIFF
--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -89,6 +89,11 @@ enum PathType {
     Rows_Augment,
 }
 
+enum ModifySequence {
+    No,
+    Change_To_Natural_Numbers,
+}
+
 enum Direction {
     Right,
     Left,
@@ -425,6 +430,7 @@ class Grid extends VisualizerDefault {
     preset = Preset.Custom
     pathType = PathType.Spiral
     resetAndAugmentByOne = false
+    modifySequence = ModifySequence.No
     backgroundColor = BLACK
     numberColor = WHITE
 
@@ -436,6 +442,9 @@ class Grid extends VisualizerDefault {
     numberToTurnAtForSpiral = 0
     incrementForNumberToTurnAt = 1
     whetherIncrementShouldIncrement = true
+
+    // Modify Sequence variables
+    naturalNumberCounter = 0n
 
     // Properties
     propertyObjects: PropertyObject[] = []
@@ -492,7 +501,7 @@ property being tested.
          **/
         startingIndex: {
             value: this.startingIndex,
-            displayName: 'Starting Index',
+            displayName: 'Starting index',
             required: false,
             description: '',
         },
@@ -509,6 +518,17 @@ property being tested.
             value: this.pathType,
             from: PathType,
             displayName: 'Path in grid',
+            required: false,
+        },
+
+        /** md
+### Modify sequence: Changes the values of the sequence to different values
+
+         **/
+        modifySequence: {
+            value: this.modifySequence,
+            from: ModifySequence,
+            displayName: 'Modify sequence',
             required: false,
         },
 
@@ -682,7 +702,6 @@ earlier ones that use the _same_ style.)
 
             this.setCurrentNumber(this.currentIndex, augmentForRowReset)
             this.fillGridCell()
-            this.currentIndex++
             this.moveCoordinatesUsingPath(iteration)
         }
         this.sketch.noLoop()
@@ -714,7 +733,16 @@ earlier ones that use the _same_ style.)
     }
 
     setCurrentNumber(currentIndex: number, augmentForRow: bigint) {
-        this.currentNumber = this.seq.getElement(currentIndex)
+        if (this.modifySequence === ModifySequence.No) {
+            this.currentNumber = this.seq.getElement(currentIndex)
+            this.currentIndex++
+        } else if (
+            this.modifySequence === ModifySequence.Change_To_Natural_Numbers
+        ) {
+            this.currentNumber = this.naturalNumberCounter
+            this.naturalNumberCounter++
+        }
+
         this.currentNumber = this.currentNumber + augmentForRow
     }
 

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -540,6 +540,7 @@ property being tested.
         /** md
 ### Modify sequence: Changes the values of the sequence to different values
 
+-Change_to_natural_numbers makes natural numbers the base sequence
          **/
         modifySequence: {
             value: this.modifySequence,
@@ -550,7 +551,6 @@ property being tested.
 
         /** md
 ### Natural numbers starting number: The number the natural numbers start at
-
          **/
         naturalNumbersStartingNumber: {
             value: this.naturalNumbersStartingNumber,
@@ -562,9 +562,8 @@ property being tested.
         },
 
         /** md
-### Make non-sequence numbers constant: Changes the values of non-sequence
-    numbers to one value.
-
+### Make sequence numbers constant: Changes the values of sequence numbers
+    to one value
          **/
         makeSequenceNumbersConstant: {
             value: this.makeSequenceNumbersConstant,
@@ -577,7 +576,7 @@ property being tested.
         },
 
         /** md
-### Constant value for non-sequence numbers: The value non-sequence numbers
+### Constant value for sequence numbers: The value non-sequence numbers
 are changed to
      **/
         sequenceNumbersConstant: {
@@ -591,7 +590,7 @@ are changed to
 
         /** md
 ### Make non-sequence numbers constant: Changes the values of non-sequence
-    numbers to one value.
+    numbers to one value
          **/
         makeNonSequenceNumbersConstant: {
             value: this.makeNonSequenceNumbersConstant,

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -1,6 +1,6 @@
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
 import {VisualizerDefault} from '@/visualizers/VisualizerDefault'
-import {bigabs, floorSqrt, modulo} from '@/shared/math'
+import {bigabs, floorSqrt, modulo, safeNumber} from '@/shared/math'
 import type {ParamInterface} from '@/shared/Paramable'
 import type {Factorization} from '@/sequences/SequenceInterface'
 import simpleFactor from '@/sequences/simpleFactor'
@@ -444,7 +444,8 @@ class Grid extends VisualizerDefault {
     whetherIncrementShouldIncrement = true
 
     // Modify Sequence variables
-    naturalNumberCounter = 0n
+    naturalNumbersCounter = 0n
+    naturalNumbersStartingNumber = 0
 
     // Properties
     propertyObjects: PropertyObject[] = []
@@ -530,6 +531,19 @@ property being tested.
             from: ModifySequence,
             displayName: 'Modify sequence',
             required: false,
+        },
+
+        /** md
+### Modify sequence: Changes the values of the sequence to different values
+
+         **/
+        naturalNumbersStartingNumber: {
+            value: this.naturalNumbersStartingNumber,
+            displayName: 'Natural Numbers Starting Number',
+            required: false,
+            visibleDependency: 'modifySequence',
+            visiblePredicate: (dependentValue: ModifySequence) =>
+                dependentValue === ModifySequence.Change_To_Natural_Numbers,
         },
 
         /** md
@@ -682,6 +696,7 @@ earlier ones that use the _same_ style.)
 
     draw(): void {
         this.currentIndex = Math.max(this.startingIndex, this.seq.first)
+        this.naturalNumbersCounter = BigInt(this.naturalNumbersStartingNumber)
         let augmentForRowReset = 0n
 
         for (
@@ -695,6 +710,10 @@ earlier ones that use the _same_ style.)
                     this.currentIndex = Math.max(
                         this.startingIndex,
                         this.seq.first
+                    )
+
+                    this.naturalNumbersCounter = BigInt(
+                        this.naturalNumbersStartingNumber
                     )
                     augmentForRowReset++
                 }
@@ -739,8 +758,8 @@ earlier ones that use the _same_ style.)
         } else if (
             this.modifySequence === ModifySequence.Change_To_Natural_Numbers
         ) {
-            this.currentNumber = this.naturalNumberCounter
-            this.naturalNumberCounter++
+            this.currentNumber = this.naturalNumbersCounter
+            this.naturalNumbersCounter++
         }
 
         this.currentNumber = this.currentNumber + augmentForRow

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -457,8 +457,10 @@ class Grid extends VisualizerDefault {
     // Modify Sequence variables
     naturalNumbersCounter = 0n
     naturalNumbersStartingNumber = 0
+    makeSequenceNumbersConstant = false
+    sequenceNumbersConstant = -1
     makeNonSequenceNumbersConstant = false
-    constantValueForNonSequenceNumbers = 0
+    nonSequenceNumbersConstant = -2
 
     // Properties
     propertyObjects: PropertyObject[] = []
@@ -552,7 +554,7 @@ property being tested.
          **/
         naturalNumbersStartingNumber: {
             value: this.naturalNumbersStartingNumber,
-            displayName: 'Natural Numbers Starting Number',
+            displayName: 'Natural numbers start at',
             required: false,
             visibleDependency: 'modifySequence',
             visiblePredicate: (dependentValue: ModifySequence) =>
@@ -564,10 +566,37 @@ property being tested.
     numbers to one value.
 
          **/
+        makeSequenceNumbersConstant: {
+            value: this.makeSequenceNumbersConstant,
+            forceType: 'boolean',
+            displayName: 'Make sequence numbers constant',
+            required: false,
+            visibleDependency: 'modifySequence',
+            visiblePredicate: (dependentValue: ModifySequence) =>
+                dependentValue === ModifySequence.Change_To_Natural_Numbers,
+        },
+
+        /** md
+### Constant value for non-sequence numbers: The value non-sequence numbers
+are changed to
+     **/
+        sequenceNumbersConstant: {
+            value: this.sequenceNumbersConstant,
+            displayName: 'Sequence numbers',
+            required: false,
+            visibleDependency: 'makeSequenceNumbersConstant',
+            visiblePredicate: (dependentValue: boolean) =>
+                dependentValue === true,
+        },
+
+        /** md
+### Make non-sequence numbers constant: Changes the values of non-sequence
+    numbers to one value.
+         **/
         makeNonSequenceNumbersConstant: {
             value: this.makeNonSequenceNumbersConstant,
             forceType: 'boolean',
-            displayName: 'Make Non-Sequence Numbers Constant',
+            displayName: 'Make non-sequence numbers constant',
             required: false,
             visibleDependency: 'modifySequence',
             visiblePredicate: (dependentValue: ModifySequence) =>
@@ -578,13 +607,13 @@ property being tested.
 ### Constant value for non-sequence numbers: The value non-sequence numbers
     are changed to
          **/
-        constantValueForNonSequenceNumbers: {
-            value: this.constantValueForNonSequenceNumbers,
-            displayName: 'Non Sequence Numbers',
+        nonSequenceNumbersConstant: {
+            value: this.nonSequenceNumbersConstant,
+            displayName: 'Non sequence numbers',
             required: false,
-            visibleDependency: 'modifySequence',
-            visiblePredicate: (dependentValue: ModifySequence) =>
-                dependentValue === ModifySequence.Change_To_Natural_Numbers,
+            visibleDependency: 'makeNonSequenceNumbersConstant',
+            visiblePredicate: (dependentValue: boolean) =>
+                dependentValue === true,
         },
 
         /** md
@@ -804,7 +833,10 @@ earlier ones that use the _same_ style.)
             this.currentNumber = this.naturalNumbersCounter
             this.naturalNumbersCounter++
 
-            if (this.makeNonSequenceNumbersConstant) {
+            if (
+                this.makeSequenceNumbersConstant
+                || this.makeNonSequenceNumbersConstant
+            ) {
                 //Increase index until sequence element at index isn't less than
                 //current number
                 if (this.currentIndex < this.seq.last) {
@@ -820,17 +852,33 @@ earlier ones that use the _same_ style.)
                     }
                 }
 
-                if (
-                    this.seq.getElement(currentIndex) !== this.currentNumber
-                ) {
-                    this.currentNumber = BigInt(
-                        this.constantValueForNonSequenceNumbers
-                    )
+                if (this.makeSequenceNumbersConstant) {
+                    if (
+                        this.seq.getElement(currentIndex)
+                        === this.currentNumber
+                    ) {
+                        this.currentNumber = BigInt(
+                            this.sequenceNumbersConstant
+                        )
+                    }
                 }
 
+                if (this.makeNonSequenceNumbersConstant) {
+                    if (
+                        this.seq.getElement(currentIndex)
+                        !== this.currentNumber
+                    ) {
+                        this.currentNumber = BigInt(
+                            this.nonSequenceNumbersConstant
+                        )
+                    }
+                }
+
+                /*
                 if (this.currentIndex === this.seq.last) {
                     this.currentIndex--
                 }
+                */
             }
         }
 

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -1,6 +1,6 @@
 import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
 import {VisualizerDefault} from '@/visualizers/VisualizerDefault'
-import {bigabs, floorSqrt, modulo, safeNumber} from '@/shared/math'
+import {bigabs, floorSqrt, modulo} from '@/shared/math'
 import type {ParamInterface} from '@/shared/Paramable'
 import type {Factorization} from '@/sequences/SequenceInterface'
 import simpleFactor from '@/sequences/simpleFactor'
@@ -446,6 +446,8 @@ class Grid extends VisualizerDefault {
     // Modify Sequence variables
     naturalNumbersCounter = 0n
     naturalNumbersStartingNumber = 0
+    makeNonSequenceNumbersConstant = false
+    constantValueForNonSequenceNumbers = 0
 
     // Properties
     propertyObjects: PropertyObject[] = []
@@ -534,12 +536,40 @@ property being tested.
         },
 
         /** md
-### Modify sequence: Changes the values of the sequence to different values
+### Natural numbers starting number: The number the natural numbers start at
 
          **/
         naturalNumbersStartingNumber: {
             value: this.naturalNumbersStartingNumber,
             displayName: 'Natural Numbers Starting Number',
+            required: false,
+            visibleDependency: 'modifySequence',
+            visiblePredicate: (dependentValue: ModifySequence) =>
+                dependentValue === ModifySequence.Change_To_Natural_Numbers,
+        },
+
+        /** md
+### Make non-sequence numbers constant: Changes the values of non-sequence numbers
+    to one value.
+
+         **/
+        makeNonSequenceNumbersConstant: {
+            value: this.makeNonSequenceNumbersConstant,
+            forceType: 'boolean',
+            displayName: 'Make Non-Sequence Numbers Constant',
+            required: false,
+            visibleDependency: 'modifySequence',
+            visiblePredicate: (dependentValue: ModifySequence) =>
+                dependentValue === ModifySequence.Change_To_Natural_Numbers,
+        },
+
+        /** md
+### Constant value for non-sequence numbers: The value non-sequence numbers are changed
+    to
+         **/
+        constantValueForNonSequenceNumbers: {
+            value: this.constantValueForNonSequenceNumbers,
+            displayName: 'Non Sequence Numbers',
             required: false,
             visibleDependency: 'modifySequence',
             visiblePredicate: (dependentValue: ModifySequence) =>
@@ -720,6 +750,7 @@ earlier ones that use the _same_ style.)
             }
 
             this.setCurrentNumber(this.currentIndex, augmentForRowReset)
+
             this.fillGridCell()
             this.moveCoordinatesUsingPath(iteration)
         }
@@ -760,6 +791,34 @@ earlier ones that use the _same_ style.)
         ) {
             this.currentNumber = this.naturalNumbersCounter
             this.naturalNumbersCounter++
+
+            if (this.makeNonSequenceNumbersConstant) {
+                //Increase index until sequence element at index isn't less than current number
+                if (this.currentIndex < this.seq.last) {
+                    for (let x = 0; x < 1000; x++) {
+                        if (
+                            this.seq.getElement(this.currentIndex)
+                            < this.currentNumber
+                        ) {
+                            this.currentIndex++
+                        } else {
+                            break
+                        }
+                    }
+                }
+
+                if (
+                    this.seq.getElement(currentIndex) !== this.currentNumber
+                ) {
+                    this.currentNumber = BigInt(
+                        this.constantValueForNonSequenceNumbers
+                    )
+                }
+
+                if (this.currentIndex === this.seq.last) {
+                    this.currentIndex--
+                }
+            }
         }
 
         this.currentNumber = this.currentNumber + augmentForRow

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -112,6 +112,7 @@ const leftTurn: Record<string, Direction> = {
 
 enum Property {
     None,
+    Equals,
     Prime,
     Negative,
     Even,
@@ -132,6 +133,7 @@ enum PropertyVisualization {
 }
 
 const propertyAuxName: Record<string, string> = {
+    Equals: 'Equals',
     Divisible_By: 'Divisor',
     Last_Digit_Is: 'Digit',
     Polygonal_Number: 'Sides',
@@ -290,6 +292,14 @@ function isPrime(factors: Factorization): boolean {
     return false // two or more prime factors
 }
 
+function equals(number: bigint, order = 3n) {
+    if (number === order) {
+        return true
+    } else {
+        return false
+    }
+}
+
 // Adapted from Geeks for Geeks:
 // https://www.geeksforgeeks.org/deficient-number/
 function getSumOfProperDivisors(num: bigint): bigint {
@@ -404,6 +414,7 @@ const propertyIndicatorFunction: {
 } = {
     None: () => false,
     Prime: isPrime,
+    Equals: equals,
     Negative: (v: bigint) => v < 0n,
     Even: congruenceIndicator(2n, 0n),
     Odd: congruenceIndicator(2n, 1n),
@@ -549,8 +560,8 @@ property being tested.
         },
 
         /** md
-### Make non-sequence numbers constant: Changes the values of non-sequence numbers
-    to one value.
+### Make non-sequence numbers constant: Changes the values of non-sequence
+    numbers to one value.
 
          **/
         makeNonSequenceNumbersConstant: {
@@ -564,8 +575,8 @@ property being tested.
         },
 
         /** md
-### Constant value for non-sequence numbers: The value non-sequence numbers are changed
-    to
+### Constant value for non-sequence numbers: The value non-sequence numbers
+    are changed to
          **/
         constantValueForNonSequenceNumbers: {
             value: this.constantValueForNonSequenceNumbers,
@@ -632,6 +643,7 @@ that property holds for a given integer.
 will be used.  Choosing anything other than none will add a new property
 and reveal parameters for it.
 - Prime:  Its absolute value is prime
+- Equals: Same as a value
 - Negative:  Less than zero
 - Even:  Divisible by two
 - Odd: Not even
@@ -793,7 +805,8 @@ earlier ones that use the _same_ style.)
             this.naturalNumbersCounter++
 
             if (this.makeNonSequenceNumbersConstant) {
-                //Increase index until sequence element at index isn't less than current number
+                //Increase index until sequence element at index isn't less than
+                //current number
                 if (this.currentIndex < this.seq.last) {
                     for (let x = 0; x < 1000; x++) {
                         if (


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This pull request implements a modify sequence capability, which allows the user to change the base sequence to the natural numbers. They can then change where number the natural numbers start at. They also can change numbers that are in the actual sequence to constant values, and they can change numbers that aren't in the actual sequence to constant values. This only works for increasing sequences.

Implementing this specific capability may seem strange because it is a round about way of allowing the user to highlight sequence numbers on the natural numbers. The issue with just having a property in the properties drop down to do this or to have there be an option the user checks with a check box is that it actually offers the user less versatile capabilities because then they can no longer highlight the sequence and specific properties about that sequence. This way of implementing it also allows for other ways of modifying the number sequence.

\<Please provide a high-level description of your PR.\>
