### PR TITLE
Histogram Factors Visualizer: enhancement: mouseover and y-axis

### DIFF
--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -198,10 +198,15 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         const mouseX = this.sketch.mouseX
         const mouseY = this.sketch.mouseY
         const binIndex = Math.floor((mouseX - largeOffsetNumber) / binWidth)
+        const xAxisHeight = largeOffsetScalar * this.sketch.height
         if (
             mouseY
-                > largeOffsetScalar * this.sketch.height // below top
-                    - height * this.binFactorArray[binIndex]
+                // hard to mouseover tiny bars, so minimum height to catch mouse
+                > Math.min(
+                    largeOffsetScalar * this.sketch.height
+                        - height * this.binFactorArray[binIndex],
+                    xAxisHeight - 10
+                )
             // and above axis
             && mouseY < largeOffsetScalar * this.sketch.height
         ) {
@@ -209,19 +214,20 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         }
 
         // Draw the axes
+        const yAxisPosition = largeOffsetNumber
         this.sketch.line(
             // Draws the y-axis
-            largeOffsetNumber,
+            yAxisPosition,
             0,
-            largeOffsetNumber,
+            yAxisPosition,
             this.sketch.height
         )
         this.sketch.line(
             // Draws the x-axis
             0,
-            largeOffsetScalar * this.sketch.height,
+            xAxisHeight,
             this.sketch.width,
-            largeOffsetScalar * this.sketch.height
+            xAxisHeight
         )
 
         for (let i = 0; i < 30; i++) {
@@ -323,6 +329,7 @@ class FactorHistogramVisualizer extends VisualizerDefault {
             const boxWidth = this.sketch.width * 0.15
             const textVerticalSpacing = this.sketch.textAscent()
             const boxHeight = textVerticalSpacing * 2.3
+            // don't want box to wander past right edge of canvas
             const boxX = Math.min(mouseX, this.sketch.width - boxWidth)
             const boxY = mouseY - boxHeight
             const boxRadius = Math.floor(smallOffsetNumber)

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -23,6 +23,7 @@ class FactorHistogramVisualizer extends VisualizerDefault {
     binSize = 1
     terms = 100
     firstIndex = NaN
+    mouseOver = true
 
     params = {
         /** md
@@ -56,6 +57,18 @@ class FactorHistogramVisualizer extends VisualizerDefault {
             value: this.terms,
             forceType: 'integer',
             displayName: 'Number of Terms',
+            required: true,
+        },
+
+        /** md
+- Mouse Over:   This turns on a mouse over feature that shows you the height
+                of the bin that you are currently hovering over, as well as
+                the number of prime factors that bin has.
+         **/
+        mouseOver: {
+            value: this.mouseOver,
+            forceType: 'boolean',
+            displayName: 'Mouse Over',
             required: true,
         },
     }
@@ -155,7 +168,7 @@ class FactorHistogramVisualizer extends VisualizerDefault {
             -Infinity
         )
         // 0.95 Creates a small offset from the side of the screen
-        return (0.95 * this.sketch.width) / greatestValue
+        return (0.95 * this.sketch.height) / greatestValue
     }
 
     draw() {
@@ -166,28 +179,30 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         const height = this.height()
         const binWidth = this.binWidth()
         const binFactorArray = this.binFactorArray()
-        const offsetScalar = 0.975
-        const textOffsetScalar = 0.995
+        const largeOffsetScalar = 0.975
+        const smallOffsetScalar = 0.995
+        const largeOffsetNumber = (1 - largeOffsetScalar) * this.sketch.width
+        const smallOffsetNumber = (1 - smallOffsetScalar) * this.sketch.width
         this.sketch.line(
             // Draws the y-axis
-            (1 - offsetScalar) * this.sketch.width,
+            largeOffsetNumber,
             0,
-            (1 - offsetScalar) * this.sketch.width,
+            largeOffsetNumber,
             this.sketch.height
         )
         this.sketch.line(
             // Draws the x-axis
             0,
-            offsetScalar * this.sketch.height,
+            largeOffsetScalar * this.sketch.height,
             this.sketch.width,
-            offsetScalar * this.sketch.height
+            largeOffsetScalar * this.sketch.height
         )
 
         for (let i = 0; i < 30; i++) {
             this.sketch.rect(
                 // Draws the rectangles for the Histogram
-                (1 - offsetScalar) * this.sketch.width + binWidth * i,
-                offsetScalar * this.sketch.height
+                largeOffsetNumber + binWidth * i,
+                largeOffsetScalar * this.sketch.height
                     - height * binFactorArray[i],
                 binWidth,
                 height * binFactorArray[i]
@@ -208,21 +223,126 @@ class FactorHistogramVisualizer extends VisualizerDefault {
                 // Draws text for if the bin size is not 1
                 this.sketch.text(
                     this.binSize * i + ' - ' + (this.binSize * (i + 1) - 1),
-                    1 - offsetScalar + binWidth * (i + 1 / 2),
-                    textOffsetScalar * this.sketch.width
+                    1 - largeOffsetScalar + binWidth * (i + 1 / 2),
+                    smallOffsetScalar * this.sketch.width
                 )
             } else {
                 // Draws text for if the bin size is 1
                 this.sketch.text(
                     i,
-                    (1 - offsetScalar) * this.sketch.width
-                        + (binWidth * (i + 1) - binWidth / 2),
-                    textOffsetScalar * this.sketch.width
+                    largeOffsetNumber + (binWidth * (i + 1) - binWidth / 2),
+                    smallOffsetScalar * this.sketch.width
                 )
             }
         }
 
-        this.sketch.noLoop()
+        let tickHeight = Math.floor(
+            (0.95 * this.sketch.height) / (height * 5)
+        )
+
+        // Sets the tickHeight to 1 if the calculated value is less than 1
+        if (tickHeight === 0) {
+            tickHeight = 1
+        }
+        // Draws the markings on the Y-axis
+        for (let i = 0; i < 9; i++) {
+            // Draws the tick marks
+            this.sketch.line(
+                largeOffsetNumber / 2,
+                this.sketch.height
+                    - largeOffsetNumber
+                    - tickHeight * height * (i + 1),
+                (3 * largeOffsetNumber) / 2,
+                this.sketch.height
+                    - largeOffsetNumber
+                    - tickHeight * height * (i + 1)
+            )
+
+            // Places the numbers on the right side of the axis if
+            // they are too big or the left side if they are small enough
+            if (tickHeight > binFactorArray[0]) {
+                this.sketch.text(
+                    tickHeight * (i + 1),
+                    (3 * largeOffsetNumber) / 2,
+                    this.sketch.height
+                        - largeOffsetNumber
+                        - tickHeight * height * (i + 1)
+                        + (3 * smallOffsetNumber) / 2
+                )
+            } else {
+                this.sketch.text(
+                    tickHeight * (i + 1),
+                    0,
+                    this.sketch.height
+                        - largeOffsetNumber
+                        - tickHeight * height * (i + 1)
+                        + (3 * smallOffsetNumber) / 2
+                )
+            }
+        }
+
+        const mouseX = this.sketch.mouseX
+        const mouseY = this.sketch.mouseY
+        const binIndex = Math.floor((mouseX - largeOffsetNumber) / binWidth)
+        let inBin = false
+        const boxHeight = this.sketch.width * 0.06
+        const boxWidth = this.sketch.width * 0.15
+
+        // Checks to see whether the mouse is in the bin drawn on the screen
+        if (
+            mouseY
+                > largeOffsetScalar * this.sketch.height
+                    - height * binFactorArray[binIndex]
+            && mouseY / height < largeOffsetScalar * this.sketch.height
+        ) {
+            inBin = true
+        }
+
+        // Draws the box and the text inside the box
+        if (inBin === true && this.mouseOver === true) {
+            this.sketch.rect(
+                mouseX,
+                mouseY - boxHeight,
+                boxWidth,
+                boxHeight,
+                Math.floor(smallOffsetNumber),
+                Math.floor(smallOffsetNumber),
+                Math.floor(smallOffsetNumber),
+                0
+            )
+
+            // Draws the text for the number of prime factors
+            // that bin represents
+            this.sketch.text(
+                'Factors:',
+                mouseX + smallOffsetNumber,
+                mouseY - boxHeight + largeOffsetNumber
+            )
+            this.sketch.text(
+                binIndex,
+                mouseX
+                    + boxWidth
+                    - 3 * smallOffsetNumber * binIndex.toString().length,
+                mouseY - boxHeight + largeOffsetNumber
+            )
+
+            // Draws the text for the number of elements of the sequence
+            // in the bin
+            this.sketch.text(
+                'Height:',
+                mouseX + smallOffsetNumber,
+                mouseY - boxHeight + largeOffsetNumber * 2
+            )
+            this.sketch.text(
+                binFactorArray[binIndex],
+                mouseX
+                    + boxWidth
+                    - 3
+                        * smallOffsetNumber
+                        * binFactorArray[binIndex].toString().length,
+                mouseY - boxHeight + largeOffsetNumber * 2
+            )
+        }
     }
 }
 

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -194,23 +194,25 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         let binTextSize = 0
 
         // Checks to see whether the mouse is in the bin drawn on the screen
-        let inBin = false
         const mouseX = this.sketch.mouseX
         const mouseY = this.sketch.mouseY
         const binIndex = Math.floor((mouseX - largeOffsetNumber) / binWidth)
         const xAxisHeight = largeOffsetScalar * this.sketch.height
-        if (
-            mouseY
-                // hard to mouseover tiny bars, so minimum height to catch mouse
-                > Math.min(
-                    largeOffsetScalar * this.sketch.height
-                        - height * this.binFactorArray[binIndex],
-                    xAxisHeight - 10
-                )
-            // and above axis
-            && mouseY < largeOffsetScalar * this.sketch.height
-        ) {
-            inBin = true
+        let inBin = false
+        if (this.mouseOver) {
+            if (
+                mouseY
+                    // hard to mouseover tiny bars; min height to catch mouse
+                    > Math.min(
+                        largeOffsetScalar * this.sketch.height
+                            - height * this.binFactorArray[binIndex],
+                        xAxisHeight - 10
+                    )
+                // and above axis
+                && mouseY < largeOffsetScalar * this.sketch.height
+            ) {
+                inBin = true
+            }
         }
 
         // Draw the axes
@@ -231,7 +233,7 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         )
 
         for (let i = 0; i < 30; i++) {
-            if (inBin && i == binIndex) {
+            if (this.mouseOver && inBin && i == binIndex) {
                 this.sketch.fill(200, 200, 200)
             } else {
                 this.sketch.fill('white')
@@ -325,7 +327,7 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         }
 
         // Draws the box and the text inside the box
-        if (inBin === true && this.mouseOver === true) {
+        if (this.mouseOver === true && inBin === true) {
             const boxWidth = this.sketch.width * 0.15
             const textVerticalSpacing = this.sketch.textAscent()
             const boxHeight = textVerticalSpacing * 2.3

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -33,7 +33,7 @@ class FactorHistogramVisualizer extends VisualizerDefault {
     firstIndex = NaN
     mouseOver = true
 
-    binFactorArray: any = []
+    binFactorArray: number[] = []
 
     params = {
         /** md

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -284,17 +284,16 @@ class FactorHistogramVisualizer extends VisualizerDefault {
                 tickNudge = (3 * largeOffsetNumber) / 2
             }
             // Avoid placing text that will get cut off
-            if (
-                tickHeight * (i + 1)
-                < this.sketch.height - 30 * this.sketch.textAscent()
-            ) {
+            const tickYPosition =
+                this.sketch.height
+                - largeOffsetNumber
+                - tickHeight * height * (i + 1)
+                + (3 * smallOffsetNumber) / 2
+            if (tickYPosition > this.sketch.textAscent()) {
                 this.sketch.text(
                     tickHeight * (i + 1),
                     tickNudge,
-                    this.sketch.height
-                        - largeOffsetNumber
-                        - tickHeight * height * (i + 1)
-                        + (3 * smallOffsetNumber) / 2
+                    tickYPosition
                 )
             }
         }
@@ -310,9 +309,10 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         // Checks to see whether the mouse is in the bin drawn on the screen
         if (
             mouseY
-                > largeOffsetScalar * this.sketch.height
+                > largeOffsetScalar * this.sketch.height // below top
                     - height * binFactorArray[binIndex]
-            && mouseY / height < largeOffsetScalar * this.sketch.height
+            // and above axis
+            && mouseY < largeOffsetScalar * this.sketch.height
         ) {
             inBin = true
         }

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -389,6 +389,9 @@ class FactorHistogramVisualizer extends VisualizerDefault {
                 boxY + textVerticalSpacing * 2
             )
         }
+        if (this.mouseOver === false) {
+            this.sketch.noLoop()
+        }
     }
 }
 

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -21,7 +21,6 @@ bar corresponds to a range of possible Omega values (a bin).
 The height of each bar shows how many entries in the sequence
 have a corresponding value of Omega.
 
-Originally designed by Devlin Costello.
 
 ## Parameters
 **/
@@ -72,7 +71,7 @@ class FactorHistogramVisualizer extends VisualizerDefault {
         /** md
 - Mouse Over:   This turns on a mouse over feature that shows you the height
                 of the bin that you are currently hovering over, as well as
-		the bin label (which Omega values are included).
+		the bin label (i.e., which Omega values are included).
          **/
         mouseOver: {
             value: this.mouseOver,


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR is an improved version of #228 which will be closed in favour of this one.  This is a rebased version of that PR (i.e. cherry-picked the commits from that PR), with improvements to code and removal of bugs (at the level expected if I had reviewed the PR myself).  Besides some cleaning up of documentation, and some slight tweaking of visual spacing to allow for text, the scope is no larger than that PR.  Namely, it resolves #220 by adding a mouseover feature which shows the stats for each histogram bar, and adds tickmarks to the y-axis.  It touches only the visualizer file itself.  The original PR has a fair quota of magic numbers and I haven't sorted through it all, although it is a little improved.  Feedback appreciated.
