### PR TITLE
fix: Tolerate visualizer inhabit()ing a new div before removal from old

### DIFF
--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -42,8 +42,8 @@
             this.viz.show()
             setTimeout(() => this.viz.stop(), 500)
         },
-        unmounted() {
-            this.viz.dispose()
+        beforeUnmount() {
+            this.viz.depart(document.getElementById(this.cid) as HTMLElement)
         },
         methods: {},
         props: {

--- a/src/components/CanvasArea.vue
+++ b/src/components/CanvasArea.vue
@@ -46,8 +46,10 @@
             )
             this.activeViz.show()
         },
-        unmounted() {
-            this.activeViz.dispose()
+        beforeUnmount() {
+            this.activeViz.depart(
+                document.getElementById('visualizer-here') as HTMLElement
+            )
         },
     })
 </script>

--- a/src/visualizers/P5Visualizer.ts
+++ b/src/visualizers/P5Visualizer.ts
@@ -70,6 +70,11 @@ export class P5Visualizer extends WithP5 implements VisualizerInterface {
      * @param element HTMLElement  Where the visualizer should inject itself
      */
     inhabit(element: HTMLElement): void {
+        if (this.within === element) return // already inhabiting there
+        if (this.within) {
+            // oops, already inhabiting somewhere else; depart there
+            this.depart(this.within)
+        }
         if (!this.isValid) {
             throw (
                 'The visualizer is not valid. '
@@ -182,9 +187,14 @@ export class P5Visualizer extends WithP5 implements VisualizerInterface {
     /**
      * Get rid of the visualization altogether
      */
-    dispose(): void {
-        this._sketch?.remove()
+    depart(element: HTMLElement): void {
+        if (!this._sketch || !this.within) {
+            throw 'Attempt to dispose P5Visualizer that is not on view.'
+        }
+        if (this.within !== element) return // that view already departed
+        this._sketch.remove()
         this._sketch = undefined
         this._canvas = undefined
+        this.within = undefined
     }
 }

--- a/src/visualizers/P5Visualizer.ts
+++ b/src/visualizers/P5Visualizer.ts
@@ -197,4 +197,22 @@ export class P5Visualizer extends WithP5 implements VisualizerInterface {
         this._canvas = undefined
         this.within = undefined
     }
+    /* Further remarks on realizing visualizers in the DOM with inhabit()
+       and depart():
+
+       If an HTML element (usually a div) gets removed from the DOM while
+       a visualizer is still inhabiting it, the visualizer becomes a
+       troublesome "ghost": the user can't see or interact with it, but
+       it's still listening for events and consuming system resources.
+       There are two ways to prevent this:
+
+       1. Immediately tell the visualizer to depart the div you're removing.
+
+       2. Immediately tell the visualizer to inhabit a div that is still in
+          the DOM.
+
+       It's safe for these calls to happen redundantly. If you tell a
+       visualizer to depart a div that it's not inhabiting, or to inhabit
+       a div that it's already inhabiting, nothing will happen.
+    */
 }

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -31,9 +31,11 @@ export interface VisualizerInterface extends ParamableInterface {
      */
     view(seq: SequenceInterface): void
     /**
-     * Provide the element that the visualizer will now realize itself
-     * within. The visualizer should stop any prior visualizations,
-     * and prepare to draw within the provided element.
+     * Cause the visualizer to realize itself within a DOM element.
+     * The visualizer should remove itself from any other location it might
+     * have been displaying, and prepare to draw within the provided element.
+     * It is safe to call this with the same element in which
+     * the visualizer is already displaying.
      * @param element HTMLElement The DOM node where the visualizer should
      *     insert itself.
      */
@@ -47,9 +49,14 @@ export interface VisualizerInterface extends ParamableInterface {
      */
     stop(): void
     /**
-     * Throw out the visualization, release its resources, etc.
+     * Remove the visualization from a DOM element, release its resources, etc.
+     * It is an error to call this if the visualization is not currently
+     * inhabit()ing any element. If the visualization is currently
+     * inhabit()ing a different element, it is presumed that the realization
+     * in that element was already cleaned up, and this is a no-op.
      * Note that after this call, it is ok to call inhabit() again,
      * possibly with a different div, to reinitialize it.
+     * @param element HTMLElement The DOM node the visualizer was inhabit()ing
      */
-    dispose(): void
+    depart(element: HTMLElement): void
 }


### PR DESCRIPTION
  Refactors the VisualizerInterface to require matching inhabit() and
  depart() calls, both taking an HTMLElement where its view will reside.
  A second inhabit() before any depart() automatically calls depart()
  on the prior view.

  Resolves #295.

By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.