### PR TITLE
refactor: Improve uniformity of VisualizerInterface and P5Visualizer

### DIFF
--- a/src/components/BundleCard.vue
+++ b/src/components/BundleCard.vue
@@ -2,9 +2,12 @@
     <div class="col-4-sm">
         <div class="card" style="width: 18rem">
             <div class="card-body">
-                <h5 class="card-title">{{ seq.name + ' + ' + viz.name }}</h5>
+                <h5 class="card-title">
+                    {{ `${viz.visualization()} of ${seq.name}` }}
+                </h5>
                 <p class="card-text">
-                    This is a bundle of {{ seq.name + ' + ' + viz.name }}.
+                    Display {{ seq.name }} using a {{ viz.visualization() }}
+                    visualization.
                 </p>
                 <div class="card-preview" :id="cid"></div>
                 <div class="card-buttons">

--- a/src/visualizers/Chaos.ts
+++ b/src/visualizers/Chaos.ts
@@ -460,5 +460,5 @@ class Chaos extends P5Visualizer {
 
 export const exportModule = new VisualizerExportModule(
     Chaos,
-    'Chaos game played using a sequence to select moves.'
+    'Chaos game played using a sequence to select moves'
 )

--- a/src/visualizers/Chaos.ts
+++ b/src/visualizers/Chaos.ts
@@ -50,7 +50,7 @@ enum ColorStyle {
 // circles fade to the outside
 
 class Chaos extends P5Visualizer {
-    name = 'Chaos'
+    static visualizationName = 'Chaos'
     corners = 4
     frac = 0.5
     walkers = 1
@@ -383,7 +383,6 @@ class Chaos extends P5Visualizer {
     }
 
     draw() {
-        super.draw()
         const sketch = this.sketch
         // we do pixelsPerFrame pixels each time through the draw cycle;
         // this speeds things up essentially
@@ -460,7 +459,6 @@ class Chaos extends P5Visualizer {
 }
 
 export const exportModule = new VisualizerExportModule(
-    'Chaos',
     Chaos,
-    'Chaos game played on a sequence.'
+    'Chaos game played using a sequence to select moves.'
 )

--- a/src/visualizers/Differences.ts
+++ b/src/visualizers/Differences.ts
@@ -17,7 +17,7 @@ between the terms in the row above, for as many rows as you like.
 **/
 
 class Differences extends P5Visualizer {
-    name = 'Differences'
+    static visualizationName = 'Differences'
 
     n = 20
     levels = 5
@@ -58,8 +58,8 @@ class Differences extends P5Visualizer {
         return status
     }
 
-    inhabit(element: HTMLElement): void {
-        super.inhabit(element)
+    setup(): void {
+        super.setup()
         if (!this.levels) {
             this.levels = this.n
             this.refreshParams()
@@ -73,7 +73,6 @@ class Differences extends P5Visualizer {
     }
 
     draw() {
-        super.draw()
         const sketch = this.sketch
         const sequence = this.seq
         const fontSize = 20
@@ -125,7 +124,6 @@ class Differences extends P5Visualizer {
 }
 
 export const exportModule = new VisualizerExportModule(
-    'Differences',
     Differences,
     'Produces a table of differences between consecutive terms, '
         + 'potentially iterated several times.'

--- a/src/visualizers/Differences.ts
+++ b/src/visualizers/Differences.ts
@@ -125,6 +125,6 @@ class Differences extends P5Visualizer {
 
 export const exportModule = new VisualizerExportModule(
     Differences,
-    'Produces a table of differences between consecutive terms, '
-        + 'potentially iterated several times.'
+    'Produces a table of differences between consecutive entries, '
+        + 'potentially iterated several times'
 )

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -416,7 +416,7 @@ const propertyIndicatorFunction: {
 }
 
 class Grid extends P5Visualizer {
-    name = 'Grid'
+    static visualizationName = 'Grid'
 
     // Grid variables
     amountOfNumbers = 4096
@@ -660,7 +660,6 @@ earlier ones that use the _same_ style.)
     }
 
     draw(): void {
-        super.draw()
         this.currentIndex = Math.max(this.startingIndex, this.seq.first)
         let augmentForRowReset = 0n
 
@@ -887,9 +886,8 @@ earlier ones that use the _same_ style.)
 }
 
 export const exportModule = new VisualizerExportModule(
-    'Grid',
     Grid,
-    'Puts numbers in a grid.'
+    'Puts numbers in a grid, highlight cells based on various properties.'
 )
 
 /** md

--- a/src/visualizers/Grid.ts
+++ b/src/visualizers/Grid.ts
@@ -887,7 +887,7 @@ earlier ones that use the _same_ style.)
 
 export const exportModule = new VisualizerExportModule(
     Grid,
-    'Puts numbers in a grid, highlight cells based on various properties.'
+    'Puts numbers in a grid, highlighting cells based on various properties'
 )
 
 /** md

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -25,8 +25,8 @@ have a corresponding value of Omega.
 ## Parameters
 **/
 
-class FactorHistogramVisualizer extends P5Visualizer {
-    name = 'Factor Histogram'
+class FactorHistogram extends P5Visualizer {
+    static visualizationName = 'Factor Histogram'
 
     binSize = 1
     terms = 100
@@ -258,7 +258,6 @@ class FactorHistogramVisualizer extends P5Visualizer {
     }
 
     draw() {
-        super.draw()
         const sketch = this.sketch
         if (this.binFactorArray.length == 0) {
             this.binFactorArraySetup()
@@ -394,7 +393,6 @@ _Originally contributed by Devlin Costello._
  **/
 
 export const exportModule = new VisualizerExportModule(
-    'Factor Histogram',
-    FactorHistogramVisualizer,
+    FactorHistogram,
     'Displays a Histogram of the number of prime factors of a sequence.'
 )

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -394,5 +394,5 @@ _Originally contributed by Devlin Costello._
 
 export const exportModule = new VisualizerExportModule(
     FactorHistogram,
-    'Displays a Histogram of the number of prime factors of a sequence.'
+    'Displays a histogram of the number of prime factors of a sequence'
 )

--- a/src/visualizers/ModFill.ts
+++ b/src/visualizers/ModFill.ts
@@ -80,4 +80,7 @@ class ModFill extends P5Visualizer {
     }
 }
 
-export const exportModule = new VisualizerExportModule(ModFill)
+export const exportModule = new VisualizerExportModule(
+    ModFill,
+    'A triangular grid showing which residues occur, to each modulus.'
+)

--- a/src/visualizers/ModFill.ts
+++ b/src/visualizers/ModFill.ts
@@ -18,8 +18,8 @@ occur by watching the order the cells are filled in as the diagram is drawn.
 ## Parameters
 **/
 
-class VizModFill extends P5Visualizer {
-    name = 'Mod Fill'
+class ModFill extends P5Visualizer {
+    static visualizationName = 'Mod Fill'
     modDimension = 10n
     params = {
         /** md
@@ -72,7 +72,6 @@ class VizModFill extends P5Visualizer {
     }
 
     draw() {
-        super.draw()
         this.drawNew(this.sketch, this.i, this.seq)
         this.i++
         if (this.i == 1000 || this.i > this.seq.last) {
@@ -81,8 +80,4 @@ class VizModFill extends P5Visualizer {
     }
 }
 
-export const exportModule = new VisualizerExportModule(
-    'Mod Fill',
-    VizModFill,
-    ''
-)
+export const exportModule = new VisualizerExportModule(ModFill)

--- a/src/visualizers/ModFill.ts
+++ b/src/visualizers/ModFill.ts
@@ -82,5 +82,5 @@ class ModFill extends P5Visualizer {
 
 export const exportModule = new VisualizerExportModule(
     ModFill,
-    'A triangular grid showing which residues occur, to each modulus.'
+    'A triangular grid showing which residues occur, to each modulus'
 )

--- a/src/visualizers/NumberGlyph.ts
+++ b/src/visualizers/NumberGlyph.ts
@@ -51,7 +51,7 @@ exceeds \( 2^{53}-1 \) to be 0.
  **/
 
 class NumberGlyph extends P5Visualizer {
-    name = 'Number Glyphs'
+    static visualizationName = 'Number Glyphs'
     n = 64
     customize = false
     brightCap = 25
@@ -272,7 +272,6 @@ The default value is 25.
     }
 
     draw() {
-        super.draw()
         if (this.firstDraw == true && this.currentIndex < this.last) {
             this.sketch.noStroke()
 
@@ -403,11 +402,7 @@ The default value is 25.
     }
 }
 
-export const exportModule = new VisualizerExportModule(
-    'Number Glyphs',
-    NumberGlyph,
-    ''
-)
+export const exportModule = new VisualizerExportModule(NumberGlyph)
 
 /** md
 

--- a/src/visualizers/NumberGlyph.ts
+++ b/src/visualizers/NumberGlyph.ts
@@ -402,7 +402,10 @@ The default value is 25.
     }
 }
 
-export const exportModule = new VisualizerExportModule(NumberGlyph)
+export const exportModule = new VisualizerExportModule(
+    NumberGlyph,
+    'Map entries to colorful glyphs using their magnitudes and prime factors'
+)
 
 /** md
 

--- a/src/visualizers/P5Visualizer.ts
+++ b/src/visualizers/P5Visualizer.ts
@@ -35,11 +35,23 @@ const p5methods: P5Methods[] = Object.getOwnPropertyNames(
 ).filter(name => name != 'constructor') as P5Methods[]
 
 // Base class for implementing Visualizers that use p5.js
-export class P5Visualizer extends WithP5 implements VisualizerInterface {
+export abstract class P5Visualizer
+    extends WithP5
+    implements VisualizerInterface
+{
     private _sketch?: p5
     private _canvas?: p5.Renderer
 
-    name = 'P5-based Visualizer'
+    /* In the P5Visualizer hierarchy, the visualization() string of the
+     * visualizer is supplied by a static member called `visualizationName`.
+     */
+    static visualizationName = 'abstract P5-based Visualizer'
+    visualization(): string {
+        return (
+            Object.getPrototypeOf(this).constructor.visualizationName
+            || 'monkeypod'
+        )
+    }
     within?: HTMLElement
     get sketch(): p5 {
         if (!this._sketch) {
@@ -66,7 +78,12 @@ export class P5Visualizer extends WithP5 implements VisualizerInterface {
 
     /***
      * Places the sketch into the given HTML element, and prepares to draw.
-     * This has to create the sketch and generate the methods it needs.
+     * This has to create the sketch and generate the methods it needs. In
+     * p5-based visualizers, we presume that initialization will generally
+     * take place in the standard p5 setup() method, so only the rare
+     * visualizer that needs to interact with the DOM or affect the
+     * of the p5 object itself would need to implement an extended or replaced
+     * inhabit() method.
      * @param element HTMLElement  Where the visualizer should inject itself
      */
     inhabit(element: HTMLElement): void {
@@ -165,13 +182,12 @@ export class P5Visualizer extends WithP5 implements VisualizerInterface {
     }
 
     /**
-     * The p5 drawing function. Even though it currently does nothing
-     * it is best for derived Visualizers to call this first in case
-     * we ever want or need to put some functionality here.
+     * The p5 drawing function. This must be implemented by derived classes
+     * that actually wish to serve as Visualizers. It should use p5 methods
+     * on this.sketch to create the desired image connected with the
+     * associated sequence/parameters.
      */
-    draw(): void {
-        return
-    }
+    abstract draw(): void
 
     /**
      * What to do when the window resizes

--- a/src/visualizers/ShiftCompare.ts
+++ b/src/visualizers/ShiftCompare.ts
@@ -19,8 +19,8 @@ modulus). The pixel is colored black otherwise.
 
 // CAUTION: This is unstable with some sequences
 // Using it may crash your browser
-class VizShiftCompare extends P5Visualizer {
-    name = 'Shift Compare'
+class ShiftCompare extends P5Visualizer {
+    static visualizationName = 'Shift Compare'
     private img: p5.Image = new p5.Image(1, 1) // just a dummy
     mod = 2n
     params = {
@@ -66,7 +66,6 @@ class VizShiftCompare extends P5Visualizer {
 
     //This will be called everytime to draw
     draw() {
-        super.draw()
         const sketch = this.sketch
         // Ensure mouse coordinates are sane.
         // Mouse coordinates look they're floats by default.
@@ -116,8 +115,4 @@ class VizShiftCompare extends P5Visualizer {
     }
 }
 
-export const exportModule = new VisualizerExportModule(
-    'Shift Compare',
-    VizShiftCompare,
-    ''
-)
+export const exportModule = new VisualizerExportModule(ShiftCompare)

--- a/src/visualizers/ShiftCompare.ts
+++ b/src/visualizers/ShiftCompare.ts
@@ -115,4 +115,7 @@ class ShiftCompare extends P5Visualizer {
     }
 }
 
-export const exportModule = new VisualizerExportModule(ShiftCompare)
+export const exportModule = new VisualizerExportModule(
+    ShiftCompare,
+    'A grid showing pairwise congruence of sequence entries, to some modulus'
+)

--- a/src/visualizers/ShowFactors.ts
+++ b/src/visualizers/ShowFactors.ts
@@ -13,7 +13,7 @@ the sequence, and below each term, its prime factors.
 **/
 
 class ShowFactors extends P5Visualizer {
-    name = 'Show Factors'
+    static visualizationName = 'Show Factors'
 
     start = 1
     end = 20
@@ -41,7 +41,6 @@ class ShowFactors extends P5Visualizer {
     first = 0
 
     draw() {
-        super.draw()
         const sketch = this.sketch
         const fontSize = 20
         sketch
@@ -87,7 +86,6 @@ class ShowFactors extends P5Visualizer {
 }
 
 export const exportModule = new VisualizerExportModule(
-    'Show Factors',
     ShowFactors,
     'Produces a table of factors of a sequence.'
 )

--- a/src/visualizers/ShowFactors.ts
+++ b/src/visualizers/ShowFactors.ts
@@ -87,5 +87,5 @@ class ShowFactors extends P5Visualizer {
 
 export const exportModule = new VisualizerExportModule(
     ShowFactors,
-    'Produces a table of factors of a sequence.'
+    'Produces a table of factors of a sequence'
 )

--- a/src/visualizers/Turtle.ts
+++ b/src/visualizers/Turtle.ts
@@ -163,5 +163,5 @@ class Turtle extends P5Visualizer {
 
 export const exportModule = new VisualizerExportModule(
     Turtle,
-    'Use a sequence to steer a virtual turtle that leaves a visible trail.'
+    'Use a sequence to steer a virtual turtle that leaves a visible trail'
 )

--- a/src/visualizers/Turtle.ts
+++ b/src/visualizers/Turtle.ts
@@ -17,7 +17,7 @@ straight segment. It displays the resulting polygonal path.
 // Turtle needs work
 // Throwing the same error on previous Numberscope website
 class Turtle extends P5Visualizer {
-    name = 'Turtle'
+    static visualizationName = 'Turtle'
     private rotMap = new Map<string, number>()
     domain = [0n, 1n, 2n, 3n, 4n]
     range = [30, 45, 60, 90, 120]
@@ -104,21 +104,6 @@ class Turtle extends P5Visualizer {
     private X = 0
     private Y = 0
 
-    inhabit(element: HTMLElement) {
-        super.inhabit(element)
-        this.currentIndex = this.seq.first
-        this.orientation = 0
-        this.X = 0
-        this.Y = 0
-
-        for (let i = 0; i < this.domain.length; i++) {
-            this.rotMap.set(
-                this.domain[i].toString(),
-                (Math.PI / 180) * this.range[i]
-            )
-        }
-    }
-
     checkParameters() {
         const status = super.checkParameters()
 
@@ -136,8 +121,18 @@ class Turtle extends P5Visualizer {
 
     setup() {
         super.setup()
+        this.currentIndex = this.seq.first
+        this.orientation = 0
         this.X = this.sketch.width / 2
         this.Y = this.sketch.height / 2
+
+        for (let i = 0; i < this.domain.length; i++) {
+            this.rotMap.set(
+                this.domain[i].toString(),
+                (Math.PI / 180) * this.range[i]
+            )
+        }
+
         this.sketch
             .background(this.bgColor)
             .stroke(this.strokeColor)
@@ -146,7 +141,6 @@ class Turtle extends P5Visualizer {
     }
 
     draw() {
-        super.draw()
         const currElement = this.seq.getElement(this.currentIndex++)
         const angle = this.rotMap.get(currElement.toString())
 
@@ -167,4 +161,4 @@ class Turtle extends P5Visualizer {
     }
 }
 
-export const exportModule = new VisualizerExportModule('Turtle', Turtle, '')
+export const exportModule = new VisualizerExportModule(Turtle)

--- a/src/visualizers/Turtle.ts
+++ b/src/visualizers/Turtle.ts
@@ -161,4 +161,7 @@ class Turtle extends P5Visualizer {
     }
 }
 
-export const exportModule = new VisualizerExportModule(Turtle)
+export const exportModule = new VisualizerExportModule(
+    Turtle,
+    'Use a sequence to steer a virtual turtle that leaves a visible trail.'
+)

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -15,10 +15,10 @@ export class VisualizerExportModule {
     description: string
     visualizer: VisualizerConstructor
 
-    constructor(viz: VisualizerConstructor, description?: string) {
+    constructor(viz: VisualizerConstructor, description: string) {
         this.name = viz.visualizationName
         this.visualizer = viz
-        this.description = description || ''
+        this.description = description
     }
 }
 

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -7,6 +7,7 @@ interface VisualizerConstructor {
      * @param seq SequenceInterface The initial sequence to visualize
      */
     new (seq: SequenceInterface): VisualizerInterface
+    visualizationName: string
 }
 
 export class VisualizerExportModule {
@@ -14,18 +15,18 @@ export class VisualizerExportModule {
     description: string
     visualizer: VisualizerConstructor
 
-    constructor(
-        name: string,
-        viz: VisualizerConstructor,
-        description?: string
-    ) {
-        this.name = name
+    constructor(viz: VisualizerConstructor, description?: string) {
+        this.name = viz.visualizationName
         this.visualizer = viz
         this.description = description || ''
     }
 }
 
 export interface VisualizerInterface extends ParamableInterface {
+    /* Returns a string identifying what sort of Visualizer this is
+     * (typically would depend only on the class of the Visualizer)
+     */
+    visualization(): string
     /**
      * Change the sequence the visualizer is showing.
      */


### PR DESCRIPTION
   Three related interface changes for the Visualizer hierarchy, as
   discussed in #293. These are all designed to make some of the
   details of defining a Visualizer less confusing and more concise.

   (A) In P5Visualizer, draw() should be abstract and hence required
       on runnable derived Visualizers, since any (additional) boilerplate
       needed by all P5Visualizers would go in the function that wraps
       this method in the default inhabit() method. Thus implementation
       draw() functions no longer need to call super.draw().
   (B) Since setup() is the default p5 initialization method and can only
       be called once per sketch anyway, clarify that generally initialization
       should be carried out in setup() rather than inhabit(), in derived
       Visualizers.
   (C) Since `name` is used as an instance property in SequenceInterface
       indicating the details of the particular interface, re-designate
       that information as the return value of a `visualization()` method
       of an entity implementing the VisualizationInterface, and suggest
       that it should only depend on the class of the entity, not the
       instance. Implement this in the P5Visualizer hierarchy with
       the visualizationName static property, and modify the
       VisualizerExportModule constructor to look for it there, so that
       the visualizationName will not have to be stated twice in every
       module implementing a Visualizer. At such time as there are other
       base classes for concrete Visualizers, these conventions should
       probably be moved one level up to a common base class of all
       visualizers; there is nothing specifically related to p5 about this
       naming scheme.

By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

