### PR TITLE
doc: Restore broken and missing links 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ applies to other repos as well.)
 2. [Clone your fork of numberscope/frontscope](./doc/working-with-git-and-github.md#clone-a-repo).
 3. [Create a branch for your contribution](./doc/working-with-git-and-github.md#create-a-branch).
 4. If you are unfamiliar with them or would like a refresher,
-   [read about basic Git operations](./doc/working-with-git-and-github.md#basic-git-operations).
+   [read about basic Git operations](./doc/working-with-git-and-github.md#basic-operations).
 5. [Push your branch to GitHub](./doc/working-with-git-and-github.md#push-a-branch).
 6. [Read Numberscope's coding principles guide](./doc/code-principles.md).
 7. [Read Numberscope's style guide](./doc/code-style.md). You should also
@@ -75,9 +75,9 @@ is ready to be reviewed by someone at Numberscope, follow these steps:
    numberscope/frontscope and click "Sync fork" (see the picture below).
    ![A screenshot of the Sync fork option](./doc/img/sync-fork.png) Another
    way to do this is to
-   [add numberscope/frontscope as a remote](./doc/gitting-it-right.md#add-a-remote)
+   [add numberscope/frontscope as a remote](./doc/working-with-git-and-github.md#add-a-remote)
    and
-   [sync your fork with the remote original](./doc/gitting-it-right.md#sync-local-fork-with-remote-original).
+   [sync your fork with the remote original](./doc/working-with-git-and-github.md#sync-local-fork-with-remote-original).
 3. Navigate to the numberscope/frontscope repository. If your fork is synced
    up with the main numberscope/frontscope repository correctly, you should
    see a button (see the image below) that says "Compare & pull request".

--- a/doc/gitting-it-right.md
+++ b/doc/gitting-it-right.md
@@ -16,7 +16,7 @@ about them.
         -   Now you are working in your own fork on a dedicated feature
             branch, congrats! Read about about basic Git operations below and
             get to work making a cool visualizer!
-        -   [Read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+        -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
     -   1.B: You have made changes.
         -   1.B.1: You are working on the main branch.
             -   1.B.1.A: You made commits.
@@ -31,7 +31,7 @@ about them.
             -   Now you are working in your own fork on a dedicated feature
                 branch, congrats! Read about about basic Git operations below
                 and get to work making a cool visualizer!
-            -   [Read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+            -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
         -   1.B.2: You are working on a different branch.
             -   1.B.2.A: You have made commits.
                 -   [Create a fork](./working-with-git-and-github.md#create-a-fork).
@@ -41,7 +41,7 @@ about them.
                 -   Now you are working in your own fork on a dedicated
                     feature branch, congrats! Read about about basic Git
                     operations below and get to work making a cool visualizer!
-                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
             -   1.B.2.B: You haven't made commits.
                 -   [Commit your changes](./working-with-git-and-github.md#commit-changes).
                 -   [Create a fork](./working-with-git-and-github.md#create-a-fork).
@@ -51,7 +51,7 @@ about them.
                 -   Now you are working in your own fork on a dedicated
                     feature branch, congrats! Read about about basic Git
                     operations below and get to work making a cool visualizer!
-                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
 -   2: You have a fork of a Numberscope repository.
     -   2.A: You haven't made changes.
         -   [Clone your fork](./working-with-git-and-github.md#clone-a-repo)
@@ -61,7 +61,7 @@ about them.
         -   Now you are working in your own fork on a dedicated feature
             branch, congrats! Read about about basic Git operations below and
             get to work making a cool visualizer!
-        -   [Read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+        -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
     -   2.B: You have made changes.
         -   2.B.1: You are working on the main branch.
             -   2.B.1.A: You made commits.
@@ -74,15 +74,15 @@ about them.
                 -   Now you are working in your own fork on a dedicated
                     feature branch, congrats! Read about about basic Git
                     operations below and get to work making a cool visualizer!
-                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
         -   2.B.2: You are working on a different branch.
             -   2.B.2.A: You have made commits.
             -   This is the correct setup! Congrats. Feel free to
-                [read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+                [read about basic Git operations](./working-with-git-and-github.md#basic-operations).
             -   Keep working in this fashion.
             -   2.B.2.B: You haven't made commits.
                 -   [Commit your changes](./working-with-git-and-github.md#commit-changes).
                 -   Now you are working in your own fork on a dedicated
                     feature branch, congrats! Read about about basic Git
                     operations below and get to work making a cool visualizer!
-                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-git-operations).
+                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).

--- a/doc/making-a-visualizer.md
+++ b/doc/making-a-visualizer.md
@@ -11,7 +11,7 @@ The easiest way to build a visualizer is to extend a pre-made visualizer base
 class, which automatically sets up a graphics framework for you to use. Right
 now, there's only one base class available:
 
--   [`P5Visualizer`](#p5-visualizers) uses the
+-   [`P5Visualizer`](#making-a-p5-visualizer-in-detail) uses the
     [**p5.js**](https://p5js.org/learn/) library for graphics and user
     interaction.
 
@@ -109,9 +109,8 @@ invalid ones.
 
 Your validation can't depend on the sequence, because there might not be any
 sequence loaded when the validation check runs. You can do sequence-dependent
-validation in [`setup()`](#bulb-set-up-the-visualizer-often-used), as
-described below, but you won't be able to prompt the user for corrections at
-that point.
+validation in [`setup()`](#set-up-the-visualizer-often-used), as described
+below, but you won't be able to prompt the user for corrections at that point.
 
 -   **p5 Template:** Make sure that the step size is positive.
 -   **Differences:** Make sure that the number of terms is positive or zero,

--- a/doc/working-with-git-and-github.md
+++ b/doc/working-with-git-and-github.md
@@ -97,12 +97,17 @@ interface.)
 
 When all of those changes look right, click the big green button at the top
 right that says "Create Pull Request". This click will take you to the "Open a
-Pull Request" form. There are just two boxes you need to fill out here. The
-first is the title. GitHub will have filled in something based on the content
-of your branch. It should be in the "semantic commit message" format linked in
-the [commit](#commit-changes) section, and it should summarize the overall
-effect of your PR on the Numberscope system. So if you don't like what GitHub
-filled in, improve it before you submit.
+Pull Request" form. (Note that the first time you push a branch to git, the
+response message actually includes a quick direct link to thisform; you can
+save that away and use it later, instead of navigating through GitHub's web
+interface.)
+
+There are just two boxes you need to fill out on the form to open a pull
+request. The first is the title. GitHub will have filled in something based on
+the content of your branch. It should be in the "semantic commit message"
+format linked in the [commit](#commit-changes) section, and it should
+summarize the overall effect of your PR on the Numberscope system. So if you
+don't like what GitHub filled in, improve it before you submit.
 
 The other box is the commit description. It is prefilled with a statement you
 need to agree to -- read it over carefully to make sure you agree before you

--- a/doc/working-with-git-and-github.md
+++ b/doc/working-with-git-and-github.md
@@ -10,6 +10,7 @@ Contents
     -   [Add changes](#add-changes)
     -   [Commit changes](#commit-changes)
     -   [Push changes](#push-changes)
+    -   [Submit a pull request](#submit-a-pull-request)
 -   [Advanced operations](#advanced-operations)
     -   [Stash your changes](#stash-your-changes)
     -   [Unstash your changes](#unstash-your-changes)
@@ -69,17 +70,20 @@ git push
 Once you have a branch in working order that implements one new feature or
 fixes one bug or otherwise changes Numberscope in a coherent way, and that
 branch is pushed to your fork in the state you want to propose for inclusion
-in Numberscope, it's time to submit a pull request (PR). To do so, go to your
-fork on the GitHub website, and select your branch in the dropdown list on
-near the top left. Then in the bar just below that dropdown list, you should
-see information on how your branch compares with the current "main" branch of
-Numberscope, in terms of the number of commits it is "ahead" of main (i.e.,
-has added since the last common commit to main) and the number of commits
-"behind" main (i.e., the number of commits added in main since the last common
-commit). Ideally, your branch is not behind main at all; otherwise, maybe some
-of those commits in main might affect the changes you were working on. So if
-you see any commits behind main, you might want to go back to your working
-copy and
+in Numberscope, the first thing to do is to carefully go through the
+[pull request checklist](pull-request-checklist.md).
+
+Presuming that you have satisfied all of the guidelines in that file, it's
+time to submit a pull request (PR). To do so, go to your fork on the GitHub
+website, and select your branch in the dropdown list on near the top left.
+Then in the bar just below that dropdown list, you should see information on
+how your branch compares with the current "main" branch of Numberscope, in
+terms of the number of commits it is "ahead" of main (i.e., has added since
+the last common commit to main) and the number of commits "behind" main (i.e.,
+the number of commits added in main since the last common commit). Ideally,
+your branch is not behind main at all; otherwise, maybe some of those commits
+in main might affect the changes you were working on. So if you see any
+commits behind main, you might want to go back to your working copy and
 [sync your local fork with remote original](#sync-local-fork-with-remote-original)
 and rebase your branch on the current version of main.
 
@@ -90,15 +94,10 @@ relevant commits and all of the changes that have been made in your branch.
 Look these over one last time to make sure they are the changes you intend. If
 not, go back to your branch and fix up whatever was awry and push it again.
 
-(Note that the first time you push a branch to git, the response message
-actually includes a quick direct link to this comparison page; you can save
-that away and use it later, instead of navigating through GitHub's web
-interface.)
-
 When all of those changes look right, click the big green button at the top
 right that says "Create Pull Request". This click will take you to the "Open a
 Pull Request" form. (Note that the first time you push a branch to git, the
-response message actually includes a quick direct link to thisform; you can
+response message actually includes a quick direct link to this form; you can
 save that away and use it later, instead of navigating through GitHub's web
 interface.)
 

--- a/doc/working-with-git-and-github.md
+++ b/doc/working-with-git-and-github.md
@@ -46,9 +46,9 @@ command:
 git commit -m "put your commit message here"
 ```
 
-It's best to write your commit message in the
-[imperative](https://en.wikipedia.org/wiki/Imperative_mood) and keep it
-shorter than 50 characters.
+You should write your commit messages according to the "semantic commit
+message"
+[guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716).
 
 ### Push changes
 
@@ -63,6 +63,72 @@ version on GitHub) or to "store" your photo, issue the following command:
 ```sh
 git push
 ```
+
+### Submit a pull request
+
+Once you have a branch in working order that implements one new feature or
+fixes one bug or otherwise changes Numberscope in a coherent way, and that
+branch is pushed to your fork in the state you want to propose for inclusion
+in Numberscope, it's time to submit a pull request (PR). To do so, go to your
+fork on the GitHub website, and select your branch in the dropdown list on
+near the top left. Then in the bar just below that dropdown list, you should
+see information on how your branch compares with the current "main" branch of
+Numberscope, in terms of the number of commits it is "ahead" of main (i.e.,
+has added since the last common commit to main) and the number of commits
+"behind" main (i.e., the number of commits added in main since the last common
+commit). Ideally, your branch is not behind main at all; otherwise, maybe some
+of those commits in main might affect the changes you were working on. So if
+you see any commits behind main, you might want to go back to your working
+copy and
+[sync your local fork with remote original](#sync-local-fork-with-remote-original)
+and rebase your branch on the current version of main.
+
+In any case, when you are satisfied your branch is ready to submit as a PR,
+you will notice that report of the number of commits ahead or behind main is
+actually a link. Click on that link, and you will reach a page that shows the
+relevant commits and all of the changes that have been made in your branch.
+Look these over one last time to make sure they are the changes you intend. If
+not, go back to your branch and fix up whatever was awry and push it again.
+
+(Note that the first time you push a branch to git, the response message
+actually includes a quick direct link to this comparison page; you can save
+that away and use it later, instead of navigating through GitHub's web
+interface.)
+
+When all of those changes look right, click the big green button at the top
+right that says "Create Pull Request". This click will take you to the "Open a
+Pull Request" form. There are just two boxes you need to fill out here. The
+first is the title. GitHub will have filled in something based on the content
+of your branch. It should be in the "semantic commit message" format linked in
+the [commit](#commit-changes) section, and it should summarize the overall
+effect of your PR on the Numberscope system. So if you don't like what GitHub
+filled in, improve it before you submit.
+
+The other box is the commit description. It is prefilled with a statement you
+need to agree to -- read it over carefully to make sure you agree before you
+submit. It may also have some description extracted from your branch. If so,
+and you like the looks of that, you can just delete the
+`\<Please provide a high-level description of your PR.\>` placeholder and you
+are good to go. If not, replace that placeholder with a more detailed but
+still brief explanation of the reason, purpose, and content of your PR. If it
+takes care of any of the outstanding issues concerning Numberscope listed on
+the GitHub site for Numberscope, include at the bottom on a separate line the
+statement `Resolves #999.` (with the actual issue number in place of 999).
+
+When you are happy with the title, description, and changes made in your PR,
+and you agree with the statement that was pre-filled in the description (which
+you should leave in the description to record your agreement), you can click
+the green "Create pull request" at the bottom right corner of the description
+box. You _should_ leave the box labeled "Allow edits and access to secrets by
+maintainers" checked. Don't worry, there aren't any secrets associated with
+the Numberscope project, so you are not giving us your bank account numbers or
+anything like that.
+
+With this click, your pull request should actually truly be created, and show
+up on the [pull request list](https://github.com/numberscope/frontscope/pulls)
+in the main GitHub page for Numberscope. The maintainers of Numberscope will
+automatically be notified of your proposed code and will get back to you about
+your ideas. Thank you for submitting your work to Numberscope!
 
 ## Advanced operations
 

--- a/src/visualizers-workbench/P5VisualizerTemplate.ts
+++ b/src/visualizers-workbench/P5VisualizerTemplate.ts
@@ -23,7 +23,7 @@ import {VisualizerExportModule} from '@/visualizers/VisualizerInterface'
   src="../../assets/img/Entries/1729.png"
   width=500
   style="margin-left: 1em; margin-right: 0.5em"
-/>](../../assets/img/Entries/1729.png)
+/>](../assets/img/Entries/1729.png)
 
 This visualizer allows you to step back and forth through a sequence, showing
 each entry as a written number.


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>
  Over a number of commits, numerous missing and broken links in the
  MkDocs documentation for Numberscope had accumulated. This PR restores
  all MkDocs links to working order, including re-creating a section
  on submitting a pull request that had somehow been lost altogether in
  a previous documentation refactor.

  When this commit is checked out, `npm run doc:serve` should not issue
  any warnings or info messages mentioning files that contain a link
  that do not correspond to any actual files or anchors in the system.