### PR TITLE
Specimen browser storage [cleaned]

### DIFF
--- a/src/shared/__tests__/browserCaching.spec.ts
+++ b/src/shared/__tests__/browserCaching.spec.ts
@@ -1,0 +1,109 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest'
+import {
+    getCurrent,
+    updateCurrent,
+    saveSpecimen,
+    deleteSpecimen,
+    openSpecimen,
+} from '../browserCaching'
+
+// Mocks localStorage
+const localStorageMock = (() => {
+    let store: Record<string, string> = {}
+
+    return {
+        getItem(key: string) {
+            return store[key] || null
+        },
+        setItem(key: string, value: string) {
+            store[key] = value
+        },
+        clear() {
+            store = {}
+        },
+        removeItem(key: string) {
+            delete store[key]
+        },
+    }
+})()
+
+Object.defineProperty(global, 'localStorage', {
+    value: localStorageMock,
+})
+
+// Mock date
+const mockDate = '06/27/2024, 10:00:00'
+vi.useFakeTimers()
+vi.setSystemTime(new Date(mockDate))
+
+beforeEach(() => {
+    localStorage.clear()
+})
+
+describe('SIM functions', () => {
+    it('should get the current SIM', () => {
+        const current = {
+            url: 'https://example.com',
+            name: 'Example',
+            date: mockDate,
+        }
+        localStorage.setItem('currentSpecimen', JSON.stringify(current))
+        expect(getCurrent()).toEqual(current)
+    })
+
+    it('should update the current SIM', () => {
+        updateCurrent('https://test.com', 'Test')
+        const current = JSON.parse(
+            localStorage.getItem('currentSpecimen') as string
+        )
+        expect(current.url).toBe('https://test.com')
+        expect(current.name).toBe('Test')
+    })
+
+    it('should save a new specimen', () => {
+        saveSpecimen('https://example.com', 'Example')
+        const savedUrls = JSON.parse(
+            localStorage.getItem('savedSpecimens') as string
+        )
+        expect(savedUrls).toEqual([
+            {url: 'https://example.com', name: 'Example', date: mockDate},
+        ])
+    })
+
+    it('should update an existing specimen', () => {
+        saveSpecimen('https://example.com', 'Example')
+        saveSpecimen('https://example2.com', 'Example')
+        const savedUrls = JSON.parse(
+            localStorage.getItem('savedSpecimens') as string
+        )
+        expect(savedUrls).toEqual([
+            {url: 'https://example2.com', name: 'Example', date: mockDate},
+        ])
+    })
+
+    it('should delete a specimen by name', () => {
+        const savedUrls = [
+            {url: 'https://example1.com', name: 'Example1', date: mockDate},
+            {url: 'https://example2.com', name: 'Example2', date: mockDate},
+        ]
+        localStorage.setItem('savedSpecimens', JSON.stringify(savedUrls))
+        deleteSpecimen('Example1')
+        const updatedUrls = JSON.parse(
+            localStorage.getItem('savedSpecimens') as string
+        )
+        expect(updatedUrls).toEqual([savedUrls[1]])
+    })
+
+    it('should open a specimen by name', () => {
+        const savedUrls = [
+            {url: 'https://example1.com', name: 'Example1', date: mockDate},
+            {url: 'https://example2.com', name: 'Example2', date: mockDate},
+        ]
+        localStorage.setItem('savedSpecimens', JSON.stringify(savedUrls))
+        openSpecimen('Example1')
+        const current = JSON.parse(
+            localStorage.getItem('currentSpecimen') as string
+        )
+        expect(current).toEqual(savedUrls[0])
+    })
+})

--- a/src/shared/browserCaching.ts
+++ b/src/shared/browserCaching.ts
@@ -1,0 +1,176 @@
+/* A "SIM" (Specimen In Memory) is a triple of strings,
+    The first string contains the specimen URL
+    The second string contains the specimen name
+    The third string contains the date on which it was last saved
+*/
+
+// NON MEMORY RELATED HELPER FUNCTIONS
+interface SIM {
+    url: string
+    name: string
+    date: string
+}
+
+function getCurrentDate(): string {
+    const currentDate = new Date()
+    const options: Intl.DateTimeFormatOptions = {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    }
+    return new Intl.DateTimeFormat('en-US', options).format(currentDate)
+}
+
+//MEMORY RELATED HELPER FUNCTIONS AND VARIABLES
+
+//Keys of where the SIMs are saved (is arbitrary)
+const cacheKey = 'savedSpecimens'
+const currentKey = 'currentSpecimen'
+
+/**
+ * Fetches the array of SIMs represented in memory.
+ *
+ * @param name
+ */
+function getSIMs(): SIM[] {
+    // Retrieves the saved SIMs from browser cache
+    const savedSIMsJson = localStorage.getItem(cacheKey)
+    // Creates empty list in case none is found in browser storage
+    let savedSIMs: SIM[] = []
+
+    // Parses the saved SIMs if they exist and overrides empty savedUrls
+    if (savedSIMsJson) {
+        savedSIMs = JSON.parse(savedSIMsJson)
+    }
+
+    return savedSIMs
+}
+
+/**
+ * Fetches the SIM associated with a certain name.
+ *
+ * @param name
+ */
+function getSIMByName(name: string): SIM {
+    const savedSIMs = getSIMs()
+
+    // Finds the SIM that matches the given name
+    const SIM = savedSIMs.find(SIM => SIM.name === name)
+
+    // Return the found SIM object or null if not found
+    if (SIM) {
+        return SIM
+    } else {
+        // Throws an error if that name is not assigned to any SIM
+        throw new Error('Name not found')
+    }
+}
+
+//MAIN FUNCTIONS
+
+/**
+ * Loads the last remembered current into the memory slot.
+ * To be called whenever the website is booted up.
+ */
+export function getCurrent(): SIM {
+    // Retrieves the saved SIM in the current slot
+    const savedCurrent = localStorage.getItem(currentKey)
+
+    //Creates an empty saved SIM in case the slot is somehow empty
+    let currentSIM: SIM = {url: '', name: '', date: ''}
+
+    //Overrides the empty SIM with whatever is in the memory
+    if (savedCurrent) {
+        currentSIM = JSON.parse(savedCurrent)
+    }
+
+    return currentSIM
+}
+
+/**
+ * Overrides the url and name in the current slot.
+ * To be called whenever changes are made to the current specimen.
+ *
+ * @param url
+ * @param name
+ */
+export function updateCurrent(url: string, name: string): void {
+    // Overrides url and name in the current slot
+    const current: SIM = getCurrent()
+    current.name = name
+    current.url = url
+    localStorage.setItem(currentKey, JSON.stringify(current))
+}
+
+/**
+ * Packages the url and name into a new SIM and saves it.
+ * It also updates the "last saved" property of the SIM.
+ * If the name corresponds to an already existing SIM, it is overriden.
+ * It should be called when the user presses the save button.
+ *
+ * @param url
+ * @param name
+ */
+
+export function saveSpecimen(url: string, name: string): void {
+    const savedUrls = getSIMs()
+    const SIM = {url: url, name: name, date: getCurrentDate()}
+    let contains = false
+
+    // Searches for a SIM with a matching name,
+    // if it is found it is overriden
+    for (let i = 0; i < savedUrls.length; i++) {
+        if (savedUrls[i].name === name) {
+            savedUrls[i] = SIM
+            contains = true
+            break
+        }
+    }
+
+    // If the SIM with a matching name is not found,
+    // it appends to the end of the array
+    if (!contains) {
+        savedUrls.push(SIM)
+    }
+
+    // Saves the updated array back to the browser cache
+    localStorage.setItem(cacheKey, JSON.stringify(savedUrls))
+}
+
+/**
+ * Deletes a specimen specified by name from the cached array.
+ * It should be called when the user presses the delete button.
+ *
+ * @param name
+ */
+export function deleteSpecimen(name: string): void {
+    const savedUrls = getSIMs()
+
+    // Finds the index of the SIM object with the matching name
+    const index = savedUrls.findIndex(SIM => SIM.name === name)
+
+    // If the SIM object is found, this removes it from the array
+    if (index !== -1) {
+        savedUrls.splice(index, 1)
+    }
+
+    // Saves the updated array back to the browser cache
+    localStorage.setItem(cacheKey, JSON.stringify(savedUrls))
+}
+
+/**
+ * Loads the parameter of a SIM specified by name into current.
+ * It should be called when the user presses a specimen in the gallery.
+ * If the name is not found in memory it will throw an error.
+ *
+ * @param name
+ */
+export function openSpecimen(name: string): void {
+    const SIM = getSIMByName(name)
+
+    localStorage.setItem(currentKey, JSON.stringify(SIM))
+}

--- a/src/shared/browserCaching.ts
+++ b/src/shared/browserCaching.ts
@@ -33,8 +33,7 @@ const currentKey = 'currentSpecimen'
 
 /**
  * Fetches the array of SIMs represented in memory.
- *
- * @param name
+ * @return {SIM[]}
  */
 function getSIMs(): SIM[] {
     // Retrieves the saved SIMs from browser cache
@@ -51,9 +50,18 @@ function getSIMs(): SIM[] {
 }
 
 /**
+ * Overwrites the array of SIMS in local storage.
+ * @param {SIM[]} sims
+ */
+function putSIMs(sims: SIM[]) {
+    localStorage.setItem(cacheKey, JSON.stringify(sims))
+}
+
+/**
  * Fetches the SIM associated with a certain name.
  *
- * @param name
+ * @param {string} name
+ * @return {SIM}
  */
 function getSIMByName(name: string): SIM {
     const savedSIMs = getSIMs()
@@ -75,6 +83,7 @@ function getSIMByName(name: string): SIM {
 /**
  * Loads the last remembered current into the memory slot.
  * To be called whenever the website is booted up.
+ * @return {SIM}
  */
 export function getCurrent(): SIM {
     // Retrieves the saved SIM in the current slot
@@ -95,8 +104,8 @@ export function getCurrent(): SIM {
  * Overrides the url and name in the current slot.
  * To be called whenever changes are made to the current specimen.
  *
- * @param url
- * @param name
+ * @param {string} url
+ * @param {string} name
  */
 export function updateCurrent(url: string, name: string): void {
     // Overrides url and name in the current slot
@@ -112,54 +121,35 @@ export function updateCurrent(url: string, name: string): void {
  * If the name corresponds to an already existing SIM, it is overriden.
  * It should be called when the user presses the save button.
  *
- * @param url
- * @param name
+ * @param {string} url
+ * @param {string} name
  */
 
 export function saveSpecimen(url: string, name: string): void {
-    const savedUrls = getSIMs()
-    const SIM = {url: url, name: name, date: getCurrentDate()}
-    let contains = false
-
-    // Searches for a SIM with a matching name,
-    // if it is found it is overriden
-    for (let i = 0; i < savedUrls.length; i++) {
-        if (savedUrls[i].name === name) {
-            savedUrls[i] = SIM
-            contains = true
-            break
-        }
+    const date = getCurrentDate()
+    const savedURLs = getSIMs()
+    const existing = savedURLs.find(SIM => SIM.name === name)
+    if (existing) {
+        existing.url = url
+        existing.date = getCurrentDate()
+    } else {
+        savedURLs.push({name, url, date})
     }
-
-    // If the SIM with a matching name is not found,
-    // it appends to the end of the array
-    if (!contains) {
-        savedUrls.push(SIM)
-    }
-
-    // Saves the updated array back to the browser cache
-    localStorage.setItem(cacheKey, JSON.stringify(savedUrls))
+    putSIMs(savedURLs)
 }
 
 /**
  * Deletes a specimen specified by name from the cached array.
  * It should be called when the user presses the delete button.
  *
- * @param name
+ * @param {string} name
  */
 export function deleteSpecimen(name: string): void {
-    const savedUrls = getSIMs()
-
-    // Finds the index of the SIM object with the matching name
-    const index = savedUrls.findIndex(SIM => SIM.name === name)
-
-    // If the SIM object is found, this removes it from the array
-    if (index !== -1) {
-        savedUrls.splice(index, 1)
-    }
-
-    // Saves the updated array back to the browser cache
-    localStorage.setItem(cacheKey, JSON.stringify(savedUrls))
+    const savedURLs = getSIMs()
+    const index = savedURLs.findIndex(SIM => SIM.name === name)
+    // If the SIM object is found, remove it from the array
+    if (index !== -1) savedURLs.splice(index, 1)
+    putSIMs(savedURLs)
 }
 
 /**
@@ -167,7 +157,7 @@ export function deleteSpecimen(name: string): void {
  * It should be called when the user presses a specimen in the gallery.
  * If the name is not found in memory it will throw an error.
  *
- * @param name
+ * @param {string}name
  */
 export function openSpecimen(name: string): void {
     const SIM = getSIMByName(name)


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR is second in the PR merge chain.
Specimen browser storage

This PR adds two new files that aren't used anywhere at this point: browserCaching.spec.ts and browserCaching.ts. browserCaching.ts adds the interface for storing specimens in the browser. This file is updated in later iterations, but largely remains the same.

[Maintainer's note: we would not usually allow a PR that simply adds unused files, but are making an exception in this case for the sake of the chain of related PRs resulting from the Delft project.]

Supersedes #355.