### PR TITLE
Resizing and url integration [cleaned]

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 
         <!-- Material design icons. Use the .material-icons-sharp class to turn text into an icon -->
         <link href="https://fonts.googleapis.com/css2?family=Material+Icons+Sharp" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp" rel="stylesheet">
+
     </head>
     <body>
         <noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "prettier": "^3.2.5",
                 "prettier-eslint": "^16.3.0",
                 "prettier-eslint-cli": "^8.0.1",
-                "sass": "^1.77.1",
+                "sass": "^1.77.2",
                 "typescript": "^5.4.5",
                 "vite": "^5.2.10",
                 "vitest": "^1.5.0",
@@ -6148,9 +6148,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.77.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.1.tgz",
-            "integrity": "sha512-OMEyfirt9XEfyvocduUIOlUSkWOXS/LAt6oblR/ISXCTukyavjex+zQNm51pPCOiFKY1QpWvEH1EeCkgyV3I6w==",
+            "version": "1.77.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
+            "integrity": "sha512-eb4GZt1C3avsX3heBNlrc7I09nyT00IUuo4eFhAbeXWU2fvA7oXI53SxODVAA+zgZCk9aunAZgO+losjR3fAwA==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -11480,9 +11480,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.77.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.1.tgz",
-            "integrity": "sha512-OMEyfirt9XEfyvocduUIOlUSkWOXS/LAt6oblR/ISXCTukyavjex+zQNm51pPCOiFKY1QpWvEH1EeCkgyV3I6w==",
+            "version": "1.77.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
+            "integrity": "sha512-eb4GZt1C3avsX3heBNlrc7I09nyT00IUuo4eFhAbeXWU2fvA7oXI53SxODVAA+zgZCk9aunAZgO+losjR3fAwA==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "prettier": "^3.2.5",
         "prettier-eslint": "^16.3.0",
         "prettier-eslint-cli": "^8.0.1",
-        "sass": "^1.77.1",
+        "sass": "^1.77.2",
         "typescript": "^5.4.5",
         "vite": "^5.2.10",
         "vitest": "^1.5.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,6 +60,9 @@
         /* Bolditude */
         --ns-font-weight-medium: 500;
 
+        /* Dimensions */
+        --ns-desktop-tab-width: 300px;
+
         /* Breakpoint widths 
         Default styles should be for vertical mobile devices
         (devices narrower than --ns-breakpoint-mobile)

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -10,7 +10,7 @@
                 <span
                     class="docking material-symbols-sharp"
                     @click="dockWindow">
-                    dock_to_right
+                    dock_to_side
                 </span>
             </div>
         </div>

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -10,7 +10,7 @@
                 <span
                     class="docking material-symbols-sharp"
                     @click="dockWindow">
-                    dock_to_side
+                    dock_to_right
                 </span>
             </div>
         </div>
@@ -28,6 +28,8 @@
         positionAndSizeAllTabs,
         selectTab,
     } from '../views/Scope.vue'
+
+    const minimizedTabHeight = 110
 
     // every element with draggable class can be dragged
     interact('.tab').resizable({
@@ -62,9 +64,10 @@
                     // select the tab when it is resized
                     selectTab(tab)
                     // update the classlist with "minimized"
-                    // if the height is less or equal than 110
+                    // if the height is less or equal than the
+                    // minimized tab height
                     tab.style.height = event.rect.height + 'px'
-                    if (event.rect.height <= 110) {
+                    if (event.rect.height <= minimizedTabHeight) {
                         tab.classList.add('minimized')
                     } else {
                         tab.classList.remove('minimized')
@@ -190,13 +193,16 @@
                     positionAndSizeAllTabs()
                 } else {
                     // if we want to minimize top tab,
-                    // set height of wrapper to 110px,
+                    // set height of wrapper to the minimized tab height,
                     // if we want to minimize bottom tab,
-                    // set height (of top tab wrapper) to 100% - 90px
+                    // set height (of top tab wrapper) to 100% - XXXpx,
+                    // where XXX is a bit less than the minimized tab height
                     if (vert === 'top') {
-                        dropzoneWrapper.style.height = '110px'
+                        dropzoneWrapper.style.height = `${minimizedTabHeight}px`
                     } else {
-                        dropzoneWrapper.style.height = 'calc(100% - 90px)'
+                        // Temp variable to beat lint's line length limits :(
+                        const h = `calc(100% - ${minimizedTabHeight - 20}px)`
+                        dropzoneWrapper.style.height = h
                     }
                     content.style.overflowY = 'hidden'
                     tab.classList.add('minimized')

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -1,6 +1,19 @@
 <template>
-    <div class="tab">
-        <div class="drag"></div>
+    <div class="tab" @click="selected" last-coords-x="0" last-coords-y="0">
+        <div class="drag">
+            <div class="buttons">
+                <span
+                    class="minimize material-icons-sharp"
+                    @click="minMaxWindow">
+                    minimize
+                </span>
+                <span
+                    class="docking material-symbols-sharp"
+                    @click="dockWindow">
+                    dock_to_right
+                </span>
+            </div>
+        </div>
         <div class="content">
             <slot></slot>
         </div>
@@ -10,7 +23,11 @@
 
 <script setup lang="ts">
     import interact from 'interactjs'
-    import {positionAndSizeTab} from '../views/Scope.vue'
+    import {
+        positionAndSizeTab,
+        positionAndSizeAllTabs,
+        selectTab,
+    } from '../views/Scope.vue'
 
     // every element with draggable class can be dragged
     interact('.tab').resizable({
@@ -41,8 +58,18 @@
                 if (
                     tab instanceof HTMLElement
                     && !tab.classList.contains('docked')
-                )
+                ) {
+                    // select the tab when it is resized
+                    selectTab(tab)
+                    // update the classlist with "minimized"
+                    // if the height is less or equal than 110
                     tab.style.height = event.rect.height + 'px'
+                    if (event.rect.height <= 110) {
+                        tab.classList.add('minimized')
+                    } else {
+                        tab.classList.remove('minimized')
+                    }
+                }
             },
         },
         modifiers: [
@@ -53,7 +80,7 @@
 
             // minimum size
             interact.modifiers.restrictSize({
-                min: {width: 0, height: 128},
+                min: {width: 700, height: 90},
             }),
         ],
     })
@@ -63,9 +90,8 @@
         autoScroll: false,
 
         listeners: {
-            start: (event: Interact.InteractEvent) => {
+            start: () => {
                 document.body.style.userSelect = 'none'
-                event.target.parentElement!.style.zIndex += 10
             },
             move: dragMoveListener,
 
@@ -96,6 +122,8 @@
             target instanceof HTMLElement
             && container instanceof HTMLElement
         ) {
+            selectTab(target)
+
             const containerRect = container.getBoundingClientRect()
             const targetRect = target.getBoundingClientRect()
             // keep position in attributes
@@ -122,40 +150,219 @@
             target.setAttribute('data-y', boundedY.toString())
         }
     }
+    function minMaxWindow(event: MouseEvent) {
+        const tab = (event.currentTarget as HTMLElement).closest('.tab')
+        if (!(tab instanceof HTMLElement)) return
+
+        selectTab(tab)
+
+        const content = tab.querySelector('.content')
+        if (!(content instanceof HTMLElement)) return
+
+        // if the tab is docked, we have a different behavior
+        if (tab.classList.contains('docked')) {
+            // vertical and horizontal position of the tab
+            // (eg. top-right, where vert is top and side is right)
+            const vert = tab.getAttribute('docked')?.split('-')[0]
+            const side = tab.getAttribute('docked')?.split('-')[1]
+            // get the correct dropzone wrapper
+            const dropzoneWrapper = tab.parentElement?.querySelector(
+                '#' + side + '-dropzone-container'
+            )?.firstChild
+            if (!(dropzoneWrapper instanceof HTMLElement)) return
+
+            if (dropzoneWrapper instanceof HTMLElement) {
+                if (tab.classList.contains('minimized')) {
+                    // if we want to maximize top tab,
+                    // set height of wrapper to 400px,
+                    // if we want to maximize bottom tab,
+                    // set height (of top tab wrapper) to 100% - 400px
+                    if (vert === 'top') {
+                        dropzoneWrapper.style.height = '400px'
+                    } else {
+                        dropzoneWrapper.style.height = 'calc(100% - 400px)'
+                    }
+                    content.style.overflowY = 'scroll'
+                    tab.classList.remove('minimized')
+                    // update the size and position of all tabs
+                    positionAndSizeAllTabs()
+                } else {
+                    // if we want to minimize top tab,
+                    // set height of wrapper to 110px,
+                    // if we want to minimize bottom tab,
+                    // set height (of top tab wrapper) to 100% - 90px
+                    if (vert === 'top') {
+                        dropzoneWrapper.style.height = '110px'
+                    } else {
+                        dropzoneWrapper.style.height = 'calc(100% - 90px)'
+                    }
+                    content.style.overflowY = 'hidden'
+                    tab.classList.add('minimized')
+                    dropzoneWrapper.classList.add('resized')
+                    // update the size and position of all tabs
+                    positionAndSizeAllTabs()
+                }
+            }
+            return
+        }
+        // If the tab is minimized, maximize it
+        if (tab.classList.contains('minimized')) {
+            tab.style.height = '400px'
+            content.style.overflowY = 'scroll'
+            tab.classList.remove('minimized')
+            return
+        }
+        // If the tab is maximized, minimize it
+        else {
+            tab.style.height = '90px'
+            content.style.overflowY = 'hidden'
+            tab.classList.add('minimized')
+        }
+    }
+    function dockWindow(event: MouseEvent) {
+        const tab = (event.currentTarget as HTMLElement).closest('.tab')
+        if (!(tab instanceof HTMLElement)) return
+        // if the tab is docked, different behavior
+        if (tab.classList.contains('docked')) {
+            // get the last undocked position of the tab
+            const x =
+                (tab.getAttribute('last-coords-x') || 0).toString() + 'px'
+            const y =
+                (tab.getAttribute('last-coords-y') || 0).toString() + 'px'
+
+            // move the tab to the last undocked position
+            tab.style.left = x
+            tab.style.top = y
+            // update attributes
+            tab.setAttribute('data-x', x)
+            tab.setAttribute('data-y', y)
+
+            // update the classlist with "docked" if the tab is docked
+            const dropzone = document.querySelector(
+                '#' + tab.getAttribute('docked') + '-dropzone'
+            )
+            const dropzoneContainer = dropzone?.parentElement?.parentElement
+            if (
+                tab instanceof HTMLElement
+                && dropzone instanceof HTMLElement
+                && dropzoneContainer instanceof HTMLElement
+                && tab.classList.contains('docked')
+            ) {
+                // update classlists when undocking
+                dropzone.classList.add('empty')
+                tab.classList.remove('docked')
+                tab.setAttribute('docked', 'none')
+                // if both dropzones are empty,
+                // make the dropzone container empty aswell
+                if (
+                    dropzoneContainer.querySelectorAll('.empty').length == 2
+                ) {
+                    dropzoneContainer.classList.add('empty')
+                }
+            }
+            return
+        }
+
+        selectTab(tab)
+
+        // get current position
+        const x = parseFloat(tab.getAttribute('data-x') || '0')
+        const y = parseFloat(tab.getAttribute('data-y') || '0')
+
+        // save current position before docking
+        tab.setAttribute('last-coords-x', x.toString())
+        tab.setAttribute('last-coords-y', y.toString())
+
+        const firstDropzone = document.querySelector('#top-right-dropzone')
+        const secondDropzone = document.querySelector(
+            '#bottom-right-dropzone'
+        )
+
+        if (!(firstDropzone instanceof HTMLElement)) return
+        if (!(secondDropzone instanceof HTMLElement)) return
+
+        // if top right dropzone is empty, dock there
+        if (firstDropzone.classList.contains('empty')) {
+            positionAndSizeTab(tab, firstDropzone)
+        }
+        // otherwise dock in the bottom right dropzone
+        else {
+            positionAndSizeTab(tab, secondDropzone)
+        }
+    }
+    // select the tab when it is clicked
+    function selected(event: MouseEvent) {
+        const tab = (event.currentTarget as HTMLElement).closest('.tab')
+        if (!(tab instanceof HTMLElement)) return
+
+        selectTab(tab)
+    }
 </script>
 
 <style scoped lang="scss">
+    // mobile styles
+    .buttons {
+        display: none;
+    }
     .tab {
-        border: 1px solid var(--ns-color-black);
         width: 300px;
-        height: 200px;
-        z-index: 50;
+        height: fit-content;
     }
-
-    .resize {
-        height: 16px;
-        width: 100%;
-        position: absolute;
-        bottom: 0;
-    }
-
-    // The drag element is actually underneath the entire window
-    // This is so that dropping is more intuitive
-    .drag {
-        position: absolute;
-        height: 100%;
-        width: 100%;
-        background-color: var(--ns-color-black);
-    }
-
     .content {
         padding: 16px;
-        position: absolute;
-        top: 16px;
-        background-color: var(--ns-color-white);
         width: 100%;
-        height: calc(100% - 16px);
         overflow-y: scroll;
         overflow-x: hidden;
+        max-width: 500px;
+    }
+    // desktop styles
+    @media (min-width: 700px) {
+        .buttons {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+            padding-right: 8px;
+            padding-top: 2px;
+            padding-bottom: 2px;
+        }
+        .minimize,
+        .docking {
+            cursor: pointer;
+            color: var(--ns-color-white);
+            font-size: 12px;
+        }
+        .tab {
+            border: 1px solid var(--ns-color-black);
+            width: 300px;
+            height: 200px;
+            z-index: 50;
+        }
+
+        .resize {
+            height: 16px;
+            width: 100%;
+            position: absolute;
+            bottom: 0;
+        }
+
+        // The drag element is actually underneath the entire window
+        // This is so that dropping is more intuitive
+        .drag {
+            position: absolute;
+            height: 100%;
+            width: 100%;
+            background-color: var(--ns-color-black);
+        }
+
+        .content {
+            padding: 16px;
+            position: absolute;
+            top: 16px;
+            background-color: var(--ns-color-white);
+            width: 100%;
+            height: calc(100% - 16px);
+            overflow-y: scroll;
+            overflow-x: hidden;
+        }
     }
 </style>

--- a/src/shared/Specimen.ts
+++ b/src/shared/Specimen.ts
@@ -33,6 +33,7 @@ export class Specimen {
     private _sequence: SequenceInterface<GenericParamDescription>
     private location?: HTMLElement
     private isSetup: boolean = false
+    private size: {width: number; height: number}
 
     /**
      * Constructs a new specimen from a visualizer and a sequence.
@@ -56,6 +57,7 @@ export class Specimen {
         this._visualizer = new vizMODULES[visualizerKey].visualizer(
             this._sequence
         )
+        this.size = {width: 0, height: 0}
     }
     /**
      * Call this as soon after construction as possible once the HTML
@@ -63,10 +65,31 @@ export class Specimen {
      */
     setup(location: HTMLElement) {
         this.location = location
-        this._visualizer.view(this._sequence)
-        this._visualizer.inhabit(this.location)
-        this._visualizer.show()
+        this.size = this.calculateSize(
+            this.location.clientWidth,
+            this.location.clientHeight,
+            this.visualizer.requestedAspectRatio()
+        )
+
+        this.visualizer.view(this.sequence)
+        this.visualizer.inhabit(this.location, this.size)
+        this.visualizer.show()
         this.isSetup = true
+    }
+    /**
+     * Hard resets the specimen
+     */
+    reset() {
+        if (!this.location) return
+        this.size = this.calculateSize(
+            this.location.clientWidth,
+            this.location.clientHeight,
+            this.visualizer.requestedAspectRatio()
+        )
+
+        this.visualizer.depart(this.location)
+        this.visualizer.inhabit(this.location, this.size)
+        this.visualizer.show()
     }
     /**
      * Returns the name of this specimen
@@ -139,6 +162,61 @@ export class Specimen {
      */
     updateSequence() {
         this.visualizer.view(this.sequence)
+    }
+
+    /**
+     * Calculates the size of the visualizer in its container.
+     * @param containerWidth width of the container
+     * @param containerHeight height of the container
+     * @param aspectRatio aspect ratio requested by visualizer
+     * @returns the size of the visualizer
+     */
+    calculateSize(
+        containerWidth: number,
+        containerHeight: number,
+        aspectRatio: number | undefined
+    ): {width: number; height: number} {
+        if (aspectRatio === undefined)
+            return {
+                width: containerWidth,
+                height: containerHeight,
+            }
+        const constraint = containerWidth / containerHeight < aspectRatio
+        return {
+            width: constraint
+                ? containerWidth
+                : containerHeight * aspectRatio,
+            height: constraint
+                ? containerWidth / aspectRatio
+                : containerHeight,
+        }
+    }
+    /**
+     * This function should be called when the size of the visualizer container
+     * has changed. It calculates the size of the contents according to the
+     * aspect ratio requested and calls the resize function.
+     * @param width New width of the visualizer container
+     * @param height New height of the visualizer container
+     */
+    resized(width: number, height: number): void {
+        const newSize = this.calculateSize(
+            width,
+            height,
+            this.visualizer.requestedAspectRatio()
+        )
+
+        if (
+            this.size.width === newSize.width
+            && this.size.height === newSize.height
+        )
+            return
+
+        this.size = newSize
+
+        if (!this.visualizer.resized?.(this.size.width, this.size.height)) {
+            // Reset the visualizer if the resized function isn't implemented
+            this.reset()
+        }
     }
     /**
      * Converts the specimen to a URL as a way of saving all information

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -6,12 +6,7 @@
                 <h3>Self similarity telescope</h3>
             </div>
             <div type="button" id="change-button">
-                <span
-                    alt="Swap icon"
-                    id="change-icon"
-                    class="material-icons-sharp"
-                    >swap_horiz</span
-                >
+                <span class="material-icons-sharp">swap_horiz</span>
                 <p id="change-text">Select Visualizer</p>
             </div>
         </div>
@@ -87,6 +82,9 @@
     #change-button {
         max-width: 100px;
         width: min-content;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
     }
     #change-icon {
         display: block;

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -1,6 +1,11 @@
 <template>
     <div id="specimen-container">
-        <tab id="sequenceTab" class="tab docked" docked="top-right">
+        <tab
+            id="sequenceTab"
+            class="tab docked"
+            docked="top-right"
+            :last-coords-x="Math.floor(tabWidth / 3)"
+            :last-coords-y="Math.floor(tabWidth / 3)">
             <ParamEditor
                 title="Sequence"
                 :paramable="specimen.sequence"
@@ -11,7 +16,13 @@
                     }
                 " />
         </tab>
-        <tab id="visualiserTab" class="tab docked" docked="bottom-right">
+        <tab
+            id="visualiserTab"
+            class="tab docked"
+            docked="bottom-right"
+            last-dropzone="bottom-right"
+            :last-coords-x="Math.floor((2 * tabWidth) / 3)"
+            :last-coords-y="Math.floor((2 * tabWidth) / 3)">
             <ParamEditor
                 title="Visualizer"
                 :paramable="specimen.visualizer"
@@ -204,6 +215,12 @@
         typeof route.query.specimen === 'string'
             ? Specimen.fromURL(route.query.specimen)
             : defaultSpecimen
+    )
+
+    const tabWidth = parseInt(
+        window
+            .getComputedStyle(document.documentElement)
+            .getPropertyValue('--ns-desktop-tab-width')
     )
 
     const updateURL = () =>
@@ -404,7 +421,7 @@
     @media (min-width: 700px) {
         #sequenceTab,
         #visualiserTab {
-            width: 300px;
+            width: var(--ns-desktop-tab-width);
         }
         #specimen-container {
             height: calc(100vh - 54px);
@@ -427,7 +444,7 @@
         .dropzone-container {
             display: flex;
             flex-direction: column;
-            width: 300px;
+            width: var(--ns-desktop-tab-width);
             height: 100%;
 
             &#right-dropzone-container {

--- a/src/views/__tests__/Gallery.spec.ts
+++ b/src/views/__tests__/Gallery.spec.ts
@@ -1,0 +1,8 @@
+import Gallery from '../Gallery.vue'
+import {expect, test} from 'vitest'
+import {mount} from '@vue/test-utils'
+
+test('should contain specimen gallery', () => {
+    const wrapper = mount(Gallery, {shallow: true})
+    expect(wrapper.html()).toContain('Specimen gallery')
+})

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -40,12 +40,17 @@ export interface VisualizerInterface<PD extends GenericParamDescription>
      * Cause the visualizer to realize itself within a DOM element.
      * The visualizer should remove itself from any other location it might
      * have been displaying, and prepare to draw within the provided element.
-     * It is safe to call this with the same element in which
-     * the visualizer is already displaying.
+     * It is safe to call this with the same element in which the visualizer
+     * is already displaying.
+     * The size provided to the visualizer is the size the visualizer should
+     * assume, respecting its aspect ratio preferences. If needed, the
+     * visualizer can also query the size of the element for the full container
+     * size.
      * @param element HTMLElement The DOM node where the visualizer should
      *     insert itself.
+     * @param size The width and height the visualizer should occupy
      */
-    inhabit(element: HTMLElement): void
+    inhabit(element: HTMLElement, size: {width: number; height: number}): void
     /**
      * Show the sequence according to this visualizer.
      */
@@ -65,7 +70,20 @@ export interface VisualizerInterface<PD extends GenericParamDescription>
      * @param element HTMLElement The DOM node the visualizer was inhabit()ing
      */
     depart(element: HTMLElement): void
-
+    /**
+     * This is called when the size of the visualizer should change, either
+     * because the window is resized, or the docking configuration has changed.
+     * Visualizer writers should take care to resize their canvas and to make
+     * sure that any html elements aren't wider than the requested width.
+     * The new size is the full available size cut down to fit in the requested
+     * aspect ratio.
+     *
+     * Not implementing this function will mean that the visualizer is reset
+     * on resize
+     * @param width The new width of the visualizer (in pixels)
+     * @param height The new height of the visualizer (in pixels)
+     */
+    resized?(width: number, height: number): void
     /**
      * Provides a way for visualizers to request a specific aspect ratio for
      * its canvas. This aspect ratio is specified as a positive n > 0 where


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

      Changes to tabs
        * Added buttons that let you control the tabs without dragging
        * Support minimizing of tabs.
        * Added a highlight to the tab that is currently selected.
        * Initial mobile compatibility in the style section of Tab.vue
    
      Resizing
        * Added a reset function to a specimen. This is a hard reset that is used
          when the specimen is resized and it doesn't override resized function.
        * Added a resized function to both specimens and visualizers. It is not
          required for visualizers as they can just not do anything and the
          specimen will hard reset them.
    
      Scope
        * Adds rudimentary mobile support.

Supersedes #356.