### PR TITLE
Fix dropzone [ui2]

### DIFF
--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -430,6 +430,7 @@
         min-height: fit-content;
         padding-left: auto;
         padding-right: auto;
+        z-index: 0;
     }
     .dropzone-container {
         display: none;
@@ -439,6 +440,7 @@
         border-bottom: 1px solid var(--ns-color-black);
         height: 301px;
         width: 100%;
+        z-index: -1;
     }
     #sequenceTab {
         width: 100%;


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Fixes the reversion in #368: as a tab is dragged, the left dropzones again highlight as the tab enters the region in which the tab will dock into the zone.

Resolves #376.