### PR TITLE
Sequence and visualizer switcher [cleaned]

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,4 +29,10 @@ module.exports = {
         // For the Paramable interface, v-model directives need type annotation
         'vue/valid-v-model': 'off',
     },
+    overrides: [
+        {
+            files: ['src/components/MageExchangeA.vue'],
+            rules: {'max-len': 'off'},
+        },
+    ],
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,9 +26,11 @@
     * {
         box-sizing: border-box;
         font-family: var(--ns-font-main);
-        color: var(--ns-color-black);
     }
 
+    a {
+        color: inherit;
+    }
     html,
     body {
         margin: 0;

--- a/src/App.vue
+++ b/src/App.vue
@@ -65,18 +65,23 @@
         Default styles should be for vertical mobile devices
         (devices narrower than --ns-breakpoint-mobile)
 
-        Small devices (landscape phones)
-        @media (min-width: var(--ns-breakpoint-mobile)) { ... }
+        // Small devices (landscape phones)
+        @media (min-width: $mobile-breakpoint) { ... }
+        // Note var(...) expressions are not allowed in media queries,
+        // so it's necessary to use the global scss variables set up
+        // in src/assets/scss/_variables.scss directly, as shown
 
-        Medium devices (tablets)
-        @media (min-width: var(--ns-breakpoint-tablet)) { ... }
+        // Medium devices (tablets)
+        @media (min-width: $tablet-breakpoint) { ... }
 
         // Large devices (desktops)
-        @media (min-width: var(--ns-breakpoint-desktop)) { ... }
+        @media (min-width: $desktop-breakpoint) { ... }
         */
-        --ns-breakpoint-mobile: 580px;
-        --ns-breakpoint-tablet: 800px;
-        --ns-breakpoint-desktop: 1200px;
+        --ns-breakpoint-mobile: $mobile-breakpoint;
+        --ns-breakpoint-tablet: $tablet-breakpoint;
+        /* Not actually used at the moment:
+          --ns-breakpoint-desktop: 1200px;
+         */
     }
 
     /* Display font */

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,6 +60,7 @@
 
         /* Dimensions */
         --ns-desktop-tab-width: 300px;
+        --ns-specimen-card-width: 216px;
 
         /* Breakpoint widths 
         Default styles should be for vertical mobile devices

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1,0 +1,6 @@
+/* These variables will be included in every style section in the
+   entire project
+*/
+
+$tablet-breakpoint: 800px;
+$mobile-breakpoint: 580px;

--- a/src/components/MageExchangeA.vue
+++ b/src/components/MageExchangeA.vue
@@ -1,0 +1,46 @@
+<template>
+    <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg">
+        <path
+            d="M3.52942 11.4706V13.5882C3.52942 14.7115 3.97564 15.7888 4.76991 16.583C5.56418 17.3773 6.64144 17.8235 7.76471 17.8235H20.4706"
+            stroke="black"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round" />
+        <path
+            d="M3.52942 6.17647H16.2353C17.3586 6.17647 18.4358 6.62268 19.2301 7.41696C20.0244 8.21123 20.4706 9.28849 20.4706 10.4118V12.5294"
+            stroke="black"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round" />
+        <path
+            d="M17.2941 14.6471L20.4706 17.8235L17.2941 21"
+            stroke="black"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round" />
+        <path
+            d="M6.70589 9.35294L3.52942 6.17647L6.70589 3"
+            stroke="black"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round" />
+    </svg>
+</template>
+
+<script lang="ts">
+    import {defineComponent} from 'vue'
+
+    /* https://mageicons.com/
+       Icon mage:exchange-a
+     */
+    export default defineComponent({
+        name: 'MageExchangeA',
+    })
+</script>
+
+<style></style>

--- a/src/components/MageExchangeA.vue
+++ b/src/components/MageExchangeA.vue
@@ -7,25 +7,25 @@
         xmlns="http://www.w3.org/2000/svg">
         <path
             d="M3.52942 11.4706V13.5882C3.52942 14.7115 3.97564 15.7888 4.76991 16.583C5.56418 17.3773 6.64144 17.8235 7.76471 17.8235H20.4706"
-            stroke="black"
+            stroke="currentColor"
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round" />
         <path
             d="M3.52942 6.17647H16.2353C17.3586 6.17647 18.4358 6.62268 19.2301 7.41696C20.0244 8.21123 20.4706 9.28849 20.4706 10.4118V12.5294"
-            stroke="black"
+            stroke="currentColor"
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round" />
         <path
             d="M17.2941 14.6471L20.4706 17.8235L17.2941 21"
-            stroke="black"
+            stroke="currentColor"
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round" />
         <path
             d="M6.70589 9.35294L3.52942 6.17647L6.70589 3"
-            stroke="black"
+            stroke="currentColor"
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round" />
@@ -37,6 +37,9 @@
 
     /* https://mageicons.com/
        Icon mage:exchange-a
+       Used according to Apache Commons license; no attribution required.
+       Note that stroke colors have been changed to currentColor, to allow
+       ambient CSS color to be used.
      */
     export default defineComponent({
         name: 'MageExchangeA',

--- a/src/components/ParamEditor.vue
+++ b/src/components/ParamEditor.vue
@@ -5,15 +5,19 @@
                 {{ error }}
             </p>
         </div>
-        <div class="tab-title-bar">
-            <div>
-                <h1>{{ title }}</h1>
-                <span class="subheading">{{ paramable.name }}</span>
+        <div
+            class="title-and-button-bar button-container"
+            @click="openSwitcher">
+            <div style="flex-grow: 1">
+                <h1>Current {{ title }}</h1>
+                <div class="item-name">{{ paramable.name }}</div>
             </div>
-            <button class="change-button" @click="openSwitcher">
-                <span class="material-icons-sharp">swap_horiz</span>
-                <span class="change-button-text">Change {{ title }}</span>
-            </button>
+            <div class="change-tooltip tooltip-anchor button">
+                <MageExchangeA id="change-icon" />
+                <div class="desc-tooltip-text help-box">
+                    Change {{ title }}
+                </div>
+            </div>
         </div>
         <p class="description">{{ paramable.description }}</p>
         <div v-for="(hierarchy, name) in sortedParams" v-bind:key="name">
@@ -51,6 +55,7 @@
     } from '../shared/Paramable'
     import typeFunctions, {ParamType} from '../shared/ParamType'
     import {ValidationStatus} from '../shared/ValidationStatus'
+    import MageExchangeA from './MageExchangeA.vue'
     import ParamField from './ParamField.vue'
 
     interface ParamHierarchy {
@@ -78,6 +83,7 @@
         },
         emits: ['changed', 'openSwitcher'],
         components: {
+            MageExchangeA,
             ParamField,
         },
         computed: {
@@ -153,19 +159,37 @@
 </script>
 
 <style scoped lang="scss">
+    /* Note some classes are used from SpecimenBar.vue, e.g.
+       title-and-button-bar
+     */
     h1 {
-        font-size: 16px;
+        font-size: var(--ns-size-subheading); // sizes inverted in ParamEditor
+        // because the name of the item is more important than the title
         margin: 0;
     }
 
-    .subheading {
-        color: var(--ns-color-grey);
-        font-size: 14px;
+    .item-name {
+        // designed to mimic input areas
+        border-bottom: 1.5px solid var(--ns-color-black);
+        font-size: var(--ns-size-heading);
+        padding: 6px 8px 6px 8px;
+        width: 100%;
+    }
+
+    .change-tooltip {
+        position: relative;
+        cursor: pointer;
+    }
+
+    #change-icon {
+        position: relative;
+        top: 2px;
     }
 
     .description {
         font-size: 12px;
-        margin-bottom: 32px;
+        margin-top: 0px;
+        margin-bottom: 24px;
     }
 
     .sub-param-box {
@@ -184,35 +208,5 @@
         font-size: var(--ns-size-body);
         margin: 8px 0;
         color: red;
-    }
-
-    .tab-title-bar {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-
-        h1 {
-            margin: 0;
-            font-size: 16px;
-        }
-
-        .subheading {
-            color: var(--ns-color-grey);
-            font-size: 14px;
-        }
-
-        .change-button {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            border: 1px solid var(--ns-color-white);
-            background: none;
-            width: min-content;
-            padding: 4px;
-
-            &:hover {
-                border: 1px solid var(--ns-color-light);
-            }
-        }
     }
 </style>

--- a/src/components/ParamField.vue
+++ b/src/components/ParamField.vue
@@ -139,6 +139,19 @@
         }
     }
 
+    ::placeholder {
+        color: grey;
+        opacity: 0.5;
+    }
+    /* The below should be kept in sync with the above. Unfortunately,
+       just adding `, ::-ms-input-placeholder` to the above selector did
+       not work for reasons I do not understand.
+     */
+    ::-ms-input-placeholder {
+        color: grey;
+        opacity: 0.5;
+    }
+
     select {
         border: 1px solid var(--ns-color-black);
         background-color: var(--ns-color-white);

--- a/src/components/ParamField.vue
+++ b/src/components/ParamField.vue
@@ -38,6 +38,7 @@
                     v-bind:id="paramName"
                     v-bind:class="!status.isValid() ? 'error-field' : ''"
                     v-bind:value="value"
+                    v-bind:placeholder="placehold(param)"
                     v-on:input="updateString($event)" />
             </label>
 
@@ -60,7 +61,7 @@
 <script lang="ts">
     import {defineComponent} from 'vue'
     import type {ParamInterface} from '../shared/Paramable'
-    import {ParamType} from '../shared/ParamType'
+    import typeFunctions, {ParamType} from '../shared/ParamType'
     import {ValidationStatus} from '../shared/ValidationStatus'
 
     export default defineComponent({
@@ -104,6 +105,11 @@
                     'updateParam',
                     (e.target as HTMLInputElement).value
                 )
+            },
+            placehold(par: ParamInterface<ParamType>) {
+                if (typeof par.placeholder === 'string')
+                    return par.placeholder
+                return typeFunctions[par.type].derealize(par.default as never)
             },
         },
         data() {

--- a/src/components/SpecimenBar.vue
+++ b/src/components/SpecimenBar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="specimen-bar">
+    <div class="title-and-button-bar">
         <div class="input-container">
             <label>
                 Specimen name
@@ -9,7 +9,7 @@
                     @input="updateName($event)" />
             </label>
 
-            <div class="desc-tooltip">
+            <div class="desc-tooltip tooltip-anchor">
                 <span class="help material-icons-sharp">help</span>
                 <div class="desc-tooltip-text help-box">
                     You can enter the name you want to give this specimen
@@ -173,13 +173,17 @@
 </script>
 
 <style>
-    .specimen-bar {
+    /* Note NOT scoped, these are global styles, used also (for example)
+       in ParamEditor.vue.
+     */
+    .title-and-button-bar {
         display: flex;
         flex-direction: row;
         gap: 8px;
         justify-content: space-between;
-        align-items: flex-end;
-        padding: 8px;
+        align-items: end;
+        padding-top: 8px;
+        padding-bottom: 8px;
     }
     label {
         font-size: 12px;
@@ -189,7 +193,7 @@
         &[type='text'] {
             border: none;
             border-bottom: 1.5px solid var(--ns-color-black);
-            font-size: 14px;
+            font-size: var(--ns-size-heading-2);
             padding: 6px 8px 6px 8px;
             width: 100%;
 
@@ -202,7 +206,6 @@
     .button-container {
         display: flex;
         gap: 8px;
-        margin-right: 8px;
         .button {
             min-width: 30px;
             text-align: center;
@@ -279,7 +282,8 @@
         line-height: normal;
         text-wrap: wrap;
         visibility: hidden;
-        width: 240px;
+        width: max-content;
+        max-width: 240px;
         background-color: var(--ns-color-white);
         color: var(--ns-color-black);
         text-align: left;
@@ -294,11 +298,11 @@
             opacity 0.2s,
             visibility 0.2s;
     }
-    .desc-tooltip .desc-tooltip-text {
+    .tooltip-anchor .desc-tooltip-text {
         right: 0;
     }
 
-    .desc-tooltip:hover .desc-tooltip-text {
+    .tooltip-anchor:hover .desc-tooltip-text {
         visibility: visible;
         opacity: 1;
     }

--- a/src/components/SpecimenBar.vue
+++ b/src/components/SpecimenBar.vue
@@ -16,47 +16,49 @@
                 </div>
             </div>
         </div>
-        <div class="button material-icons-sharp" @click="refresh">
-            refresh
-        </div>
-        <div
-            id="pause-button"
-            class="button material-icons-sharp"
-            @click="togglePause">
-            pause
-        </div>
-        <div
-            id="share-button"
-            class="button material-icons-sharp"
-            @click="shareUrl">
-            share
-            <div id="share-popup" class="notification help-box">
-                URL copied to clipboard!
+        <div class="button-container">
+            <div class="button material-icons-sharp" @click="refresh">
+                refresh
             </div>
-        </div>
-        <div>
             <div
-                id="save-button"
+                id="pause-button"
                 class="button material-icons-sharp"
-                @click="checkSave()">
-                save
+                @click="togglePause">
+                pause
             </div>
-            <div id="save-popup" class="notification help-box">
-                Saved to gallery!
-            </div>
-            <div id="overwrite-popup" class="notification help-box">
-                <div id="overwrite-text">
-                    You already have a specimen with the same name, do you
-                    want to overwrite it?
+            <div
+                id="share-button"
+                class="button material-icons-sharp"
+                @click="shareUrl">
+                share
+                <div id="share-popup" class="notification help-box">
+                    URL copied to clipboard!
                 </div>
-                <div id="confirm-overwrite">
-                    <div class="overwrite-button" @click="saveCurrent">
-                        yes
+            </div>
+            <div>
+                <div
+                    id="save-button"
+                    class="button material-icons-sharp"
+                    @click="checkSave()">
+                    save
+                </div>
+                <div id="save-popup" class="notification help-box">
+                    Saved to gallery!
+                </div>
+                <div id="overwrite-popup" class="notification help-box">
+                    <div id="overwrite-text">
+                        You already have a specimen with the same name, do you
+                        want to overwrite it?
                     </div>
-                    <div
-                        class="overwrite-button"
-                        @click="removeOverwritePopup">
-                        no
+                    <div id="confirm-overwrite">
+                        <div class="overwrite-button" @click="saveCurrent">
+                            yes
+                        </div>
+                        <div
+                            class="overwrite-button"
+                            @click="removeOverwritePopup">
+                            no
+                        </div>
                     </div>
                 </div>
             </div>
@@ -215,19 +217,29 @@
             }
         }
     }
-    .button {
-        min-width: 30px;
-        text-align: center;
-        width: 30px;
-        height: 30px;
-        line-height: 30px;
-        vertical-align: middle;
-        font-size: 24px;
-        border: 1px solid var(--ns-color-black);
-        color: var(--ns-color-grey);
-        cursor: pointer;
-        user-select: none;
+    .button-container {
+        display: flex;
+        gap: 8px;
+        margin-right: 8px;
+        .button {
+            min-width: 30px;
+            text-align: center;
+            width: 30px;
+            height: 30px;
+            line-height: 30px;
+            vertical-align: middle;
+            font-size: 24px;
+            border: 1px solid var(--ns-color-black);
+            color: var(--ns-color-grey);
+            cursor: pointer;
+            user-select: none;
+
+            &:hover {
+                color: var(--ns-color-black);
+            }
+        }
     }
+
     .help {
         color: var(--ns-color-black);
     }

--- a/src/components/SpecimenBar.vue
+++ b/src/components/SpecimenBar.vue
@@ -23,9 +23,10 @@
             <div
                 id="pause-button"
                 class="button material-icons-sharp"
-                @click="togglePause">
-                pause
-            </div>
+                v-html="
+                    specimen.visualizer.isDrawing ? 'pause' : 'play_arrow'
+                "
+                @click="togglePause" />
             <div
                 id="share-button"
                 class="button material-icons-sharp"
@@ -87,27 +88,12 @@
             },
             refresh() {
                 this.specimen.updateSequence()
-                paused = false
-                this.updateButtons()
-            },
-            updateButtons() {
-                // find the pause button and change the icon based on 'paused'.
-                const playButton = document.getElementById('pause-button')
-                if (!(playButton instanceof HTMLElement)) return
-                playButton.innerHTML = paused ? 'play_arrow' : 'pause'
             },
             // toggles the pause state
             togglePause() {
-                if (paused) {
-                    // continue the visualizer
-                    this.specimen.visualizer.continue()
-                    paused = false
-                } else {
-                    // pause the visualizer
+                if (this.specimen.visualizer.isDrawing) {
                     this.specimen.visualizer.stop()
-                    paused = true
-                }
-                this.updateButtons()
+                } else this.specimen.visualizer.continue()
             },
             shareUrl() {
                 //get url
@@ -184,10 +170,6 @@
             },
         },
     })
-
-    // true if paused, false if playing
-    let paused = false
-    // refreshes the specimen
 </script>
 
 <style>

--- a/src/components/SpecimenCard.vue
+++ b/src/components/SpecimenCard.vue
@@ -7,7 +7,7 @@
                     {{ specimenName }}
                 </h5>
                 <p class="card-text">
-                    {{ seqName }}
+                    {{ useSub }}
                 </p>
             </div>
             <div
@@ -34,7 +34,8 @@
         name: 'SpecimenCard',
         props: {
             base64: {type: String, required: true},
-            lastEdited: {type: String, required: true},
+            lastEdited: {type: String},
+            subtitle: {type: String},
             permanent: {type: Boolean},
             cid: {
                 type: String,
@@ -44,10 +45,7 @@
             },
         },
         data() {
-            return {
-                seqName: '',
-                specimenName: '',
-            }
+            return {specimenName: '', useSub: ''}
         },
         methods: {
             openSpecimen() {
@@ -58,7 +56,7 @@
                             specimen: this.base64,
                         },
                     })
-                    .then(window.location.reload)
+                    .then(_value => window.location.reload())
             },
             deleteSpecimen() {
                 deleteSpecimen(this.specimenName)
@@ -66,8 +64,9 @@
             },
         },
         mounted() {
-            this.seqName = Specimen.getSequenceNameFrom64(this.base64)
             this.specimenName = Specimen.getNameFrom64(this.base64)
+            if (this.subtitle) this.useSub = this.subtitle
+            else this.useSub = Specimen.getSequenceNameFrom64(this.base64)
         },
         components: {
             Thumbnail,

--- a/src/components/SpecimenCard.vue
+++ b/src/components/SpecimenCard.vue
@@ -77,7 +77,7 @@
 <style scoped>
     .card-body {
         position: relative;
-        width: 216px;
+        width: var(--ns-specimen-card-width);
         border: 1px solid var(--ns-color-black);
         display: flex;
         flex-direction: column;
@@ -104,6 +104,7 @@
         font-size: 12px;
         margin-top: 2px;
         margin-left: 8px;
+        margin-right: 8px;
         margin-bottom: 8px;
         color: #6c757d;
     }

--- a/src/components/SpecimensGallery.vue
+++ b/src/components/SpecimensGallery.vue
@@ -1,0 +1,60 @@
+<template>
+    <div class="gallery">
+        <SpecimenCard
+            v-for="specimen in currentSpecs()"
+            :key="specimen.base64"
+            :base64="specimen.base64"
+            :subtitle="specimen.subtitle"
+            :lastEdited="specimen.lastEdited"
+            @specimenDeleted="removeSpecimen"
+            :permanent="!canDelete" />
+    </div>
+</template>
+
+<script setup lang="ts">
+    import SpecimenCard from './SpecimenCard.vue'
+    import {Specimen} from '../shared/Specimen'
+    import {ref} from 'vue'
+
+    export interface CardSpecimen {
+        base64: string
+        subtitle?: string
+        lastEdited?: string
+    }
+
+    const props = defineProps<{
+        canDelete: boolean
+        specimens: CardSpecimen[]
+    }>()
+
+    const currentSpecimens = ref(props.specimens)
+
+    function currentSpecs() {
+        if (currentSpecimens.value.length) return currentSpecimens.value
+        currentSpecimens.value = props.specimens
+        return currentSpecimens.value
+    }
+
+    function removeSpecimen(name: string) {
+        const index = currentSpecimens.value.findIndex(
+            spec => name === Specimen.getNameFrom64(spec.base64)
+        )
+        if (index > -1) currentSpecimens.value.splice(index, 1)
+    }
+</script>
+
+<style scoped>
+    .gallery {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: left;
+        margin-top: 29px;
+        gap: 29px;
+    }
+    @media (min-width: $tablet-breakpoint) {
+        .gallery {
+            gap: 16px;
+            margin: 0 0 16px 0;
+        }
+    }
+</style>

--- a/src/components/SpecimensGallery.vue
+++ b/src/components/SpecimensGallery.vue
@@ -43,7 +43,7 @@
     }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
     .gallery {
         display: flex;
         flex-wrap: wrap;
@@ -54,7 +54,7 @@
     @media (min-width: $tablet-breakpoint) {
         .gallery {
             gap: 16px;
-            margin: 0 0 16px 0;
+            margin: 16px 0 0 0;
         }
     }
 </style>

--- a/src/components/SwitcherModal.vue
+++ b/src/components/SwitcherModal.vue
@@ -1,0 +1,218 @@
+<template>
+    <div id="background" @click.self="emit('close')">
+        <div id="modal">
+            <div id="bar">
+                <button
+                    class="material-icons-sharp"
+                    alt="Close button"
+                    @click="emit('close')">
+                    close
+                </button>
+            </div>
+
+            <div id="content">
+                <h1>Change {{ category }}</h1>
+
+                <div v-if="category === 'sequence'" id="search-bar">
+                    <div>
+                        <label for="oeis">Search the OEIS</label><br />
+                        <input type="text" id="oeis" placeholder="A037161" />
+                    </div>
+                    <button class="material-icons-sharp">search</button>
+                </div>
+
+                <div id="results">
+                    <div
+                        class="switch-option"
+                        v-for="(description, item) in modules[category]"
+                        :key="item"
+                        @click="changeToItem(item), emit('close')">
+                        <h2>{{ item }}</h2>
+                        <p>{{ description }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import seqMODULES from '../sequences/sequences'
+    import vizMODULES from '../visualizers/visualizers'
+    import {Specimen} from '../shared/Specimen'
+    import type {PropType, UnwrapNestedRefs} from 'vue'
+
+    function descriptions(mods: {[key: string]: {description: string}}) {
+        return Object.fromEntries(
+            Object.keys(mods).map(k => [k, mods[k].description])
+        )
+    }
+    const modules = {
+        sequence: descriptions(seqMODULES),
+        visualizer: descriptions(vizMODULES),
+    }
+
+    const emit = defineEmits(['close', 'change'])
+    type Categories = 'sequence' | 'visualizer'
+
+    const props = defineProps({
+        category: {
+            type: String as PropType<Categories>,
+            required: true,
+        },
+        specimen: {
+            type: Object as PropType<UnwrapNestedRefs<Specimen>>,
+            required: true,
+        },
+    })
+
+    function changeToItem(item: string | number) {
+        const key = typeof item === 'string' ? item : item.toString()
+        const spec = props.specimen
+        if (props.category === 'sequence') spec.sequenceKey = key
+        else if (props.category === 'visualizer') spec.visualizerKey = key
+        else return // Maybe should throw error or something
+        emit('change')
+    }
+</script>
+
+<style scoped lang="scss">
+    h1 {
+        font-size: var(--ns-size-title);
+        margin-bottom: 16px;
+        margin-top: 0;
+    }
+
+    .switch-option {
+        width: 216px;
+        height: 268px;
+        background-color: black;
+        padding: 10px;
+        color: white;
+        cursor: pointer;
+    }
+    .switch-option p {
+        font-size: var(--ns-size-subheading);
+        color: white;
+    }
+    .switch-option h2 {
+        color: white;
+        font-size: var(--ns-size-heading);
+    }
+
+    #background {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 999;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.3);
+    }
+
+    #content {
+        padding: 16px;
+        padding-top: 0;
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: calc(100% - 48px);
+    }
+
+    #modal {
+        max-width: 900px;
+        width: 100%;
+        height: 100%;
+        background-color: var(--ns-color-white);
+        display: flex;
+        flex-direction: column;
+    }
+
+    #bar {
+        height: 48px;
+        padding: 16px;
+        background-color: var(--ns-color-white);
+        display: flex;
+        justify-content: end;
+        align-items: center;
+
+        button {
+            font-size: 24px;
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 4px;
+            color: var(--ns-color-black);
+        }
+    }
+
+    #search-bar {
+        display: flex;
+        align-items: center;
+
+        div {
+            margin-right: 8px;
+        }
+
+        label {
+            font-size: var(--ns-size-subheading);
+        }
+
+        input[type='text'] {
+            font-size: var(--ns-size-heading-2);
+            margin-bottom: 16px;
+            margin-right: 8px;
+            border: none;
+            border-bottom: var(--ns-color-black);
+            border-bottom-width: 1px;
+            border-bottom-style: solid;
+            padding: 6px 8px;
+        }
+        input[type='text']:focus {
+            outline: none;
+            border-bottom-color: var(--ns-color-primary);
+        }
+        input[type='text']::placeholder {
+            color: var(--ns-color-light);
+        }
+
+        button {
+            font-size: 24px;
+            border: 1px solid var(--ns-color-black);
+            background: none;
+            aspect-ratio: 1 / 1;
+        }
+    }
+
+    #results {
+        display: flex;
+        flex-wrap: wrap;
+        overflow: auto;
+        flex: 1;
+        gap: 16px;
+    }
+
+    @media (min-width: $tablet-breakpoint) {
+        #bar {
+            display: flex;
+            background-color: var(--ns-color-primary);
+            height: 24px;
+            padding: 0;
+
+            button {
+                color: var(--ns-color-white);
+                font-size: 16px;
+            }
+        }
+
+        #content {
+            height: calc(100% - 24px);
+            padding-top: 16px;
+        }
+
+        #modal {
+            max-height: 80%;
+        }
+    }
+</style>

--- a/src/components/SwitcherModal.vue
+++ b/src/components/SwitcherModal.vue
@@ -1,35 +1,40 @@
 <template>
-    <div id="background" @click.self="emit('close')">
-        <div ref="switcher" id="modal">
-            <div id="bar">
-                <button
-                    class="material-icons-sharp"
-                    alt="Close button"
-                    @click="emit('close')">
-                    close
-                </button>
-            </div>
-
-            <div id="content">
-                <div class="switcher-title-bar">
-                    <h1>Choose {{ category }}</h1>
-
-                    <div v-if="category === 'sequence'" id="search-bar">
-                        <div>
-                            <label for="oeis">Search the OEIS</label><br />
-                            <input
-                                type="text"
-                                id="oeis"
-                                placeholder="A037161" />
-                        </div>
-                        <button class="material-icons-sharp">search</button>
-                    </div>
+    <div id="background" class="filler" @click.self="emit('close')">
+        <div ref="aligner" id="canvas-overlay" class="filler">
+            <div ref="switcher" id="modal">
+                <div id="bar">
+                    <button
+                        class="material-icons-sharp"
+                        alt="Close button"
+                        @click="emit('close')">
+                        close
+                    </button>
                 </div>
-                <div ref="galleryContainer" class="results">
-                    <SpecimensGallery
-                        class="results"
-                        :specimens="altered(category)"
-                        :canDelete="false" />
+
+                <div id="content">
+                    <div class="switcher-title-bar">
+                        <h1>Choose {{ category }}</h1>
+
+                        <div v-if="category === 'sequence'" id="search-bar">
+                            <div>
+                                <label for="oeis">Search the OEIS</label>
+                                <br />
+                                <input
+                                    type="text"
+                                    id="oeis"
+                                    placeholder="A037161" />
+                            </div>
+                            <button class="material-icons-sharp">
+                                search
+                            </button>
+                        </div>
+                    </div>
+                    <div ref="galleryWrap" class="results">
+                        <SpecimensGallery
+                            class="results"
+                            :specimens="altered(category)"
+                            :canDelete="false" />
+                    </div>
                 </div>
             </div>
         </div>
@@ -72,17 +77,28 @@
     })
 
     const switcher = ref<HTMLElement | null>(null)
-    const galleryContainer = ref<HTMLElement | null>(null)
+    const galleryWrap = ref<HTMLElement | null>(null)
+    const aligner = ref<HTMLElement | null>(null)
     onMounted(() => {
-        // Re-dimension the modal to be (roughly) a whole number of cards
+        // On mobile the switchers just cover the screen, so nothing to do:
+        if (isMobile()) return
+        // Keep TypeScript happy:
+        if (!aligner.value || !switcher.value || !galleryWrap.value) return
+
+        // Ok, time to position the switcher. First, align with the canvas
+        // container:
+        const canvasContainer = document.getElementById('canvas-container')
+        if (!canvasContainer) return
+        const canvasRect = canvasContainer.getBoundingClientRect()
+        aligner.value.style.width = `${canvasRect.width}px`
+        aligner.value.style.left = `${canvasRect.left}px`
+
+        // Now re-dimension the modal to be (roughly) a whole number of cards
         // wide, and either just tall enough to fit all cards, or if it
         // can't be made that tall, ensure that it's _not_ roughly a
         // whole number of cards tall so that it's clear that it will be
         // necessary to scroll.
-
-        if (isMobile() || !switcher.value || !galleryContainer.value) return
-
-        const specGallery = galleryContainer.value.firstChild
+        const specGallery = galleryWrap.value.firstChild
         if (!specGallery) return
 
         const switchSty = window.getComputedStyle(switcher.value)
@@ -169,14 +185,17 @@
         margin-top: 0;
     }
 
-    #background {
+    .filler {
         position: absolute;
         display: flex;
         align-items: center;
-        justify-content: right;
-        z-index: 999;
+        justify-content: center;
         width: 100%;
         height: 100%;
+    }
+
+    #background {
+        z-index: 999;
         background-color: rgba(0, 0, 0, 0.3);
     }
 
@@ -263,10 +282,6 @@
     }
 
     @media (min-width: $tablet-breakpoint) {
-        #background {
-            padding-right: calc(var(--ns-desktop-tab-width) + 16px);
-        }
-
         #modal {
             max-height: 90%;
             max-width: 90%;

--- a/src/components/SwitcherModal.vue
+++ b/src/components/SwitcherModal.vue
@@ -1,6 +1,10 @@
 <template>
     <div id="background" class="filler" @click.self="emit('close')">
-        <div ref="aligner" id="canvas-overlay" class="filler">
+        <div
+            ref="aligner"
+            id="canvas-overlay"
+            class="filler"
+            @click.self="emit('close')">
             <div ref="switcher" id="modal">
                 <div id="bar">
                     <button

--- a/src/components/SwitcherModal.vue
+++ b/src/components/SwitcherModal.vue
@@ -11,16 +11,20 @@
             </div>
 
             <div id="content">
-                <h1>Change {{ category }}</h1>
+                <div class="switcher-title-bar">
+                    <h1>Change {{ category }}</h1>
 
-                <div v-if="category === 'sequence'" id="search-bar">
-                    <div>
-                        <label for="oeis">Search the OEIS</label><br />
-                        <input type="text" id="oeis" placeholder="A037161" />
+                    <div v-if="category === 'sequence'" id="search-bar">
+                        <div>
+                            <label for="oeis">Search the OEIS</label><br />
+                            <input
+                                type="text"
+                                id="oeis"
+                                placeholder="A037161" />
+                        </div>
+                        <button class="material-icons-sharp">search</button>
                     </div>
-                    <button class="material-icons-sharp">search</button>
                 </div>
-
                 <div id="results">
                     <div
                         class="switch-option"
@@ -77,6 +81,10 @@
 </script>
 
 <style scoped lang="scss">
+    .switcher-title-bar {
+        display: flex;
+        justify-content: space-between;
+    }
     h1 {
         font-size: var(--ns-size-title);
         margin-bottom: 16px;

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -324,8 +324,8 @@
         overflow-x: hidden;
         max-width: 500px;
     }
-    // desktop styles
-    @media (min-width: 700px) {
+    // tablet & desktop styles
+    @media (min-width: $tablet-breakpoint) {
         .buttons {
             display: flex;
             justify-content: flex-end;

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -318,7 +318,7 @@
         height: fit-content;
     }
     .content {
-        padding: 16px;
+        padding: 0px 16px 16px 16px;
         width: 100%;
         overflow-y: scroll;
         overflow-x: hidden;
@@ -364,7 +364,6 @@
         }
 
         .content {
-            padding: 16px;
             position: absolute;
             top: 16px;
             background-color: var(--ns-color-white);

--- a/src/shared/Paramable.ts
+++ b/src/shared/Paramable.ts
@@ -39,6 +39,12 @@ export interface ParamInterface<T extends ParamType> {
     // a blank input in the UI will use the `default` property instead of
     // displaying an error to the user.
     required: boolean
+    // The placeholder text that appears in the entry box for the parameter
+    // when that box is empty. This is really only applicable to non-required
+    // parameters, because for required ones, that box is not allowed to be
+    // empty. The placeholder defaults to the string representation of the
+    // default value for the parameter.
+    placeholder?: string
     /* If you want the control for this parameter only to be visible when
      * some other parameter has a specific value (because it is otherwise
      * irrelevant), set this `visibleDependency` property to the name of

--- a/src/shared/Paramable.ts
+++ b/src/shared/Paramable.ts
@@ -366,10 +366,12 @@ export class Paramable<PD extends GenericParamDescription>
 
             const tentative = this.tentativeValues[prop]
             const status = ValidationStatus.ok()
-            typeFunctions[param.type].validate(tentative, status)
+            // No need to validate empty optional params
+            if (tentative || param.required)
+                typeFunctions[param.type].validate(tentative, status)
             if (status.isValid()) {
-                const realized = typeFunctions[param.type].realize(tentative)
-                if (realized === me[prop]) continue
+                // Skip any parameters that already produce the current value
+                if (me[prop] === realizeOne(param, tentative)) continue
             }
 
             // Circumventing typescript a bit as we do above

--- a/src/shared/Specimen.ts
+++ b/src/shared/Specimen.ts
@@ -166,11 +166,8 @@ export class Specimen {
      *     the key of the desired visualizer's export module
      */
     set visualizerKey(visualizerKey: string) {
-        // TODO: Do we need to check if the previous visualizer is already
-        // inhabiting an HTML element and .depart it if so, before it is
-        // setup again? Or will garbage collection of the old visualizer take
-        // care of that?
         this._visualizerKey = visualizerKey
+        this._visualizer.depart(this.location!)
         this._visualizer = new vizMODULES[visualizerKey].visualizer(
             this._sequence
         )

--- a/src/shared/layoutUtilities.ts
+++ b/src/shared/layoutUtilities.ts
@@ -1,0 +1,9 @@
+/* Helper functions for laying out the user interface */
+export function isMobile() {
+    const tabletBreakpoint = parseInt(
+        window
+            .getComputedStyle(document.documentElement)
+            .getPropertyValue('--ns-breakpoint-tablet')
+    )
+    return window.innerWidth < tabletBreakpoint
+}

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -23,60 +23,43 @@
                 keyboard_arrow_up</span
             >
         </div>
-        <div class="gallery" v-if="showFeatured">
-            <SpecimenCard
-                v-for="specimen in featured"
-                :key="'feat' + specimen.base64"
-                :base64="specimen.base64"
-                :lastEdited="specimen.lastEdited"
-                permanent>
-            </SpecimenCard>
-        </div>
+        <SpecimensGallery
+            v-if="showFeatured"
+            :specimens="featured"
+            :canDelete="false" />
 
         <div type="button" class="visualizer-bar">
             <h2>Saved Specimens</h2>
             <span
-                :class="['material-icons-sharp', specimensArrowClass]"
+                :class="['material-icons-sharp', savedArrowClass]"
                 style="user-select: none"
                 @click="toggleSpecimens">
-                keyboard_arrow_up</span
-            >
+                keyboard_arrow_up
+            </span>
         </div>
-        <div class="gallery" v-if="showSpecimens">
-            <SpecimenCard
-                v-for="specimen in specimens"
-                :key="specimen.base64"
-                :base64="specimen.base64"
-                :lastEdited="specimen.lastEdited"
-                @specimenDeleted="loadSpecimens">
-            </SpecimenCard>
-        </div>
+        <SpecimensGallery v-if="showSaved" :specimens="saved" canDelete />
     </div>
 </template>
 
 <script setup lang="ts">
-    import SpecimenCard from '../components/SpecimenCard.vue'
+    import SpecimensGallery from '../components/SpecimensGallery.vue'
+    import type {CardSpecimen} from '../components/SpecimensGallery.vue'
     import {ref, onMounted, computed} from 'vue'
     import {getSIMs} from '../shared/browserCaching'
     import {getFeatured} from '../shared/defineFeatured'
     import type {SIM} from '../shared/browserCaching'
     import NavBar from '../views/minor/NavBar.vue'
 
-    interface cardSpecimen {
-        base64: string
-        lastEdited: string
-    }
-
-    const specimens = ref<cardSpecimen[]>([])
-    const featured = ref<cardSpecimen[]>([])
+    const saved = ref<CardSpecimen[]>([])
+    const featured = ref<CardSpecimen[]>([])
 
     const showFeatured = ref(true)
-    const showSpecimens = ref(true)
+    const showSaved = ref(true)
     const featuredArrowClass = computed(() =>
         showFeatured.value ? 'arrow-up' : 'arrow-down'
     )
-    const specimensArrowClass = computed(() =>
-        showSpecimens.value ? 'arrow-up' : 'arrow-down'
+    const savedArrowClass = computed(() =>
+        showSaved.value ? 'arrow-up' : 'arrow-down'
     )
 
     function toggleFeatured() {
@@ -84,21 +67,21 @@
     }
 
     function toggleSpecimens() {
-        showSpecimens.value = !showSpecimens.value
+        showSaved.value = !showSaved.value
     }
 
     function loadFeatured() {
         featured.value = getFeatured().map(base64 => {
-            return {base64, lastEdited: ''}
+            return {base64}
         })
     }
 
-    function loadSpecimens() {
-        specimens.value = SIMstoCards(getSIMs())
+    function loadSaved() {
+        saved.value = SIMstoCards(getSIMs())
     }
 
-    function SIMstoCards(savedSIMs: SIM[]): cardSpecimen[] {
-        const cardSpecs: cardSpecimen[] = []
+    function SIMstoCards(savedSIMs: SIM[]): CardSpecimen[] {
+        const cardSpecs: CardSpecimen[] = []
         for (const SIM of savedSIMs) {
             let base64 = SIM.en64
             // Backwards compatibility hack for specimens that may
@@ -114,7 +97,7 @@
 
     onMounted(() => {
         loadFeatured()
-        loadSpecimens()
+        loadSaved()
     })
 </script>
 
@@ -145,6 +128,7 @@
         align-items: center;
         margin: 8px 0;
     }
+
     #change-button {
         max-width: 100px;
         width: min-content;
@@ -152,10 +136,12 @@
         flex-direction: column;
         align-items: center;
     }
+
     #change-icon {
         display: block;
         margin: auto;
     }
+
     #change-text {
         font-size: var(--ns-size-mini);
         text-align: center;
@@ -167,14 +153,6 @@
 
     .visualizer-bar {
         display: none;
-    }
-
-    .gallery {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: left;
-        margin-top: 29px;
-        gap: 29px;
     }
 
     .arrow-up {
@@ -209,11 +187,6 @@
             justify-content: space-between;
             align-items: center;
             margin-bottom: 16px;
-        }
-
-        .gallery {
-            gap: 16px;
-            margin: 0 0 16px 0;
         }
     }
 </style>

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -112,6 +112,7 @@
         font-size: var(--ns-size-title);
     }
     h2 {
+        margin-top: 3ex;
         font-size: var(--ns-size-heading);
     }
     h3 {
@@ -179,7 +180,6 @@
 
         #header {
             display: block;
-            margin-bottom: 16px;
         }
 
         .visualizer-bar {

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -16,7 +16,6 @@
                     changeSequenceOpen = false
                 }
             "
-            @change="updateURL"
             :specimen="specimen" />
         <SwitcherModal
             category="visualizer"
@@ -27,7 +26,6 @@
                     changeVisualizerOpen = false
                 }
             "
-            @change="updateURL"
             :specimen="specimen" />
         <tab
             id="sequenceTab"

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -12,6 +12,7 @@
             v-if="changeSequenceOpen"
             @close="
                 () => {
+                    continueVisualizer()
                     changeSequenceOpen = false
                 }
             "
@@ -22,6 +23,7 @@
             v-if="changeVisualizerOpen"
             @close="
                 () => {
+                    continueVisualizer()
                     changeVisualizerOpen = false
                 }
             "
@@ -38,6 +40,7 @@
                 :paramable="specimen.sequence"
                 @openSwitcher="
                     () => {
+                        pauseVisualizer()
                         changeSequenceOpen = true
                     }
                 "
@@ -60,6 +63,7 @@
                 :paramable="specimen.visualizer"
                 @openSwitcher="
                     () => {
+                        pauseVisualizer()
                         changeVisualizerOpen = true
                     }
                 "
@@ -301,6 +305,13 @@
     function handleSpecimenUpdate(newName: string) {
         specimen.name = newName
         updateURL()
+    }
+
+    function pauseVisualizer() {
+        specimen.visualizer.stop()
+    }
+    function continueVisualizer() {
+        specimen.visualizer.continue()
     }
 
     let canvasContainer: HTMLElement = document.documentElement

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -124,12 +124,7 @@
     import NavBar from './minor/NavBar.vue'
     import SpecimenBar from '../components/SpecimenBar.vue'
     import {openCurrent, updateCurrent} from '@/shared/browserCaching'
-
-    const tabletBreakpoint = parseInt(
-        window
-            .getComputedStyle(document.documentElement)
-            .getPropertyValue('--ns-breakpoint-tablet')
-    )
+    import {isMobile} from '@/shared/layoutUtilities'
 
     /**
      * Positions a tab to be inside a dropzone
@@ -141,7 +136,7 @@
         tab: HTMLElement,
         dropzone: HTMLElement
     ): void {
-        if (window.innerWidth < tabletBreakpoint) return
+        if (isMobile()) return
 
         const dropzoneContainer = dropzone.parentElement?.parentElement
         const dropzoneRect = dropzone.getBoundingClientRect()

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -9,7 +9,7 @@
     <div id="specimen-container">
         <SwitcherModal
             category="sequence"
-            v-show="changeSequenceOpen"
+            v-if="changeSequenceOpen"
             @close="
                 () => {
                     changeSequenceOpen = false
@@ -19,7 +19,7 @@
             :specimen="specimen" />
         <SwitcherModal
             category="visualizer"
-            v-show="changeVisualizerOpen"
+            v-if="changeVisualizerOpen"
             @close="
                 () => {
                     changeVisualizerOpen = false
@@ -309,6 +309,9 @@
     }
 
     let canvasContainer: HTMLElement = document.documentElement
+    type IntervalID = ReturnType<typeof setInterval>
+    let resizePoll: IntervalID
+
     onMounted(() => {
         const specimenContainer = document.getElementById(
             'specimen-container'
@@ -322,7 +325,7 @@
         canvasContainer = document.getElementById('canvas-container')!
         specimen.setup(canvasContainer)
 
-        setInterval(() => {
+        resizePoll = setInterval(() => {
             specimen.resized(
                 canvasContainer.clientWidth,
                 canvasContainer.clientHeight
@@ -331,6 +334,7 @@
     })
 
     onUnmounted(() => {
+        clearInterval(resizePoll)
         specimen.visualizer.depart(canvasContainer)
     })
 

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -97,6 +97,7 @@
         }
 
         .burger-menu {
+            color: var(--ns-color-black);
             display: flex;
             flex-direction: row;
             justify-content: space-between;
@@ -113,6 +114,7 @@
             display: none;
             flex-direction: column;
             margin-top: 8px;
+            color: var(--ns-color-black);
             background-color: var(--ns-color-white);
             &.open {
                 display: flex;

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -68,14 +68,13 @@
     })
 </script>
 
-<style lang="scss" scoped>
+<style scoped lang="scss">
     nav {
         display: flex;
         flex-direction: column;
         justify-content: center;
         padding: 8px 16px 8px 16px;
         border-bottom: 1px solid var(--ns-color-black);
-        height: 76px;
 
         #navbar-main {
             display: flex;
@@ -114,14 +113,13 @@
             display: none;
             flex-direction: column;
             margin-top: 8px;
-            border-bottom: 1px solid var(--ns-color-black);
             background-color: var(--ns-color-white);
             &.open {
                 display: flex;
                 z-index: 1000;
             }
 
-            @media (min-width: var(--ns-breakpoint-mobile)) {
+            @media (min-width: $mobile-breakpoint) {
                 display: flex;
             }
 
@@ -148,7 +146,7 @@
         display: none;
     }
 
-    @media (min-width: 700px) {
+    @media (min-width: $tablet-breakpoint) {
         nav {
             justify-content: space-between;
             align-items: center;

--- a/src/visualizers/Chaos.ts
+++ b/src/visualizers/Chaos.ts
@@ -3,8 +3,7 @@ import {modulo} from '../shared/math'
 import {P5Visualizer, INVALID_COLOR} from './P5Visualizer'
 import {VisualizerExportModule} from './VisualizerInterface'
 import {ParamType} from '../shared/ParamType'
-import type {GenericParamDescription, ParamValues} from '../shared/Paramable'
-import type {SequenceInterface} from '../sequences/SequenceInterface'
+import type {ParamValues} from '../shared/Paramable'
 
 /** md
 # Chaos Visualizer
@@ -34,8 +33,6 @@ class Palette {
             this.backgroundColor = sketch.color(hexBack)
             this.textColor = sketch.color(hexText)
         } else {
-            this.backgroundColor = INVALID_COLOR
-            this.textColor = INVALID_COLOR
             this.backgroundColor = INVALID_COLOR
             this.textColor = INVALID_COLOR
         }
@@ -192,10 +189,6 @@ class Chaos extends P5Visualizer(paramDesc) {
 
     // colour palette
     private currentPalette = new Palette()
-
-    constructor(seq: SequenceInterface<GenericParamDescription>) {
-        super(seq)
-    }
 
     checkParameters(params: ParamValues<typeof paramDesc>) {
         const status = super.checkParameters(params)

--- a/src/visualizers/Chaos.ts
+++ b/src/visualizers/Chaos.ts
@@ -111,19 +111,15 @@ const paramDesc = {
         displayName: 'Starting index',
         required: false,
         description:
-            'Index of the first entry to use. If this is blank or less '
-            + 'than the first valid index, visualization will start '
-            + 'at the first valid index.',
+            'Index of the first entry to use. (Clearing this field will '
+            + 'reset it to the first valid index.)',
     },
     last: {
         default: Infinity,
         type: ParamType.INTEGER,
         displayName: 'Ending index',
         required: false,
-        description:
-            'Index of the last entry to use. If this is blank or greater '
-            + 'than the last valid index, visualization will end at the '
-            + 'last valid index.',
+        placeholder: '[unlimited]',
     },
     dummyDotControl: {
         default: false,

--- a/src/visualizers/Differences.ts
+++ b/src/visualizers/Differences.ts
@@ -49,16 +49,11 @@ row. _(Positive integer or zero. Zero means all available entries.)_
 than 'Entries in top row.')_
      **/
     levels: {
-        default: 5,
+        default: 0,
         type: ParamType.INTEGER,
         displayName: 'Number of rows',
         required: false,
-        description: 'If zero, defaults to the length of top row',
-        validate: (levels: number) =>
-            ValidationStatus.errorIf(
-                levels < 1,
-                'Number of rows must be positive'
-            ),
+        placeholder: '[length of top row]',
     },
 } as const
 
@@ -67,7 +62,6 @@ class Differences extends P5Visualizer(paramDesc) {
     description = vizDescription
 
     first = 0
-    levels = 5
 
     constructor(seq: SequenceInterface<GenericParamDescription>) {
         super(seq)
@@ -84,10 +78,6 @@ class Differences extends P5Visualizer(paramDesc) {
 
     setup(): void {
         super.setup()
-        if (!this.levels) {
-            this.levels = this.n
-            this.refreshParams()
-        }
         if (this.seq.last - this.seq.first + 1 < this.levels) {
             throw Error(
                 `Sequence ${this.seq.name} has too few entries `
@@ -99,6 +89,7 @@ class Differences extends P5Visualizer(paramDesc) {
     draw() {
         const sketch = this.sketch
         const sequence = this.seq
+        const tryLevels = this.levels > 0 ? this.levels : this.n
         const fontSize = 20
         const xDelta = 50
         const yDelta = 50
@@ -115,7 +106,7 @@ class Differences extends P5Visualizer(paramDesc) {
 
         const workingSequence = []
         const end = min(sequence.first + this.n - 1, sequence.last)
-        const levels = min(this.levels, end - this.first + 1)
+        const levels = min(tryLevels, end - this.first + 1)
 
         // workingSequence cannibalizes the first n elements
         for (let i = sequence.first; i <= end; i++) {

--- a/src/visualizers/Histogram.ts
+++ b/src/visualizers/Histogram.ts
@@ -52,6 +52,7 @@ of the histogram.
         default: NaN,
         type: ParamType.INTEGER,
         displayName: 'First Index',
+        placeholder: '[start of sequence]',
         required: false,
     },
 

--- a/src/visualizers/P5Visualizer.ts
+++ b/src/visualizers/P5Visualizer.ts
@@ -61,6 +61,7 @@ export function P5Visualizer<PD extends GenericParamDescription>(desc: PD) {
         _sketch?: p5
         _canvas?: p5.Renderer
         _size: {width: number; height: number}
+        isDrawing = false
 
         within?: HTMLElement
         get sketch(): p5 {
@@ -174,13 +175,16 @@ export function P5Visualizer<PD extends GenericParamDescription>(desc: PD) {
             // again
             const displayTimeout = 5
 
-            if (this._canvas) this._sketch?.draw()
-            else {
+            if (this._canvas) {
+                this.isDrawing = true
+                this._sketch?.draw()
+            } else {
                 // If the rendering context is not yet ready, start an interval
                 // that waits until the canvas is ready and shows when finished
                 const interval = setInterval(() => {
                     if (this._canvas) {
                         clearInterval(interval)
+                        this.isDrawing = true
                         this._sketch?.draw()
                     }
                 }, displayTimeout)
@@ -191,6 +195,7 @@ export function P5Visualizer<PD extends GenericParamDescription>(desc: PD) {
          * Stop displaying the visualizer
          */
         stop(): void {
+            this.isDrawing = false
             this._sketch?.noLoop()
         }
 
@@ -198,6 +203,7 @@ export function P5Visualizer<PD extends GenericParamDescription>(desc: PD) {
          * Continue displaying the visualizer
          */
         continue(): void {
+            this.isDrawing = true
             this._sketch?.loop()
         }
 
@@ -231,6 +237,7 @@ export function P5Visualizer<PD extends GenericParamDescription>(desc: PD) {
                 throw 'Attempt to dispose P5Visualizer that is not on view.'
             }
             if (this.within !== element) return // that view already departed
+            this.isDrawing = false
             this._sketch.remove()
             this._sketch = undefined
             this._canvas = undefined

--- a/src/visualizers/Turtle.ts
+++ b/src/visualizers/Turtle.ts
@@ -84,7 +84,7 @@ be the same length.
         default: '#666666',
         type: ParamType.COLOR,
         displayName: 'Background Color',
-        required: false,
+        required: true,
     },
     /**
 - strokeColor: The color used for drawing the path.
@@ -93,7 +93,7 @@ be the same length.
         default: '#ff0000',
         type: ParamType.COLOR,
         displayName: 'Stroke Color',
-        required: false,
+        required: true,
     },
 } as const
 

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -52,9 +52,13 @@ export interface VisualizerInterface<PD extends GenericParamDescription>
      */
     inhabit(element: HTMLElement, size: {width: number; height: number}): void
     /**
-     * Show the sequence according to this visualizer.
+     * Show the sequence according to this visualizer, i.e. start drawing
      */
     show(): void
+    /**
+     * Is the visualizer currently drawing?
+     */
+    isDrawing: boolean
     /**
      * Stop drawing the visualization
      */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
             '@': fileURLToPath(new URL('./src', import.meta.url)),
         },
     },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                additionalData: '@import "@/assets/scss/_variables.scss";',
+            },
+        },
+    },
     build: {
         target: 'esnext',
     },


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Switchers
    * Adds a new button on each tab to change the sequence/visualizer. It is still not possible to switch to an OEIS sequence (that's added in the next PR in the sequence, but changing to all other sequences/visualizers should work, provided they work themselves.

Parameter Editor
    * Updates the param editors to work with switching visualizers and specimens.
    * More specifically, when a paramable is assigned to (like in the case of switching a visualizer specimen), the watch function gets called that makes sure to reset all the statuses of the parameters. This is so that no errors are carried over from the previous visualizer/sequence.

Specimen bar
    * Refactors the buttons in the bar into a button container, and reworks the save button popup to fix some visual bugs.

Mobile
    * Changes the mobile vs tablet-desktop breakpoint  to 800px, as the specimen bar occupies a lot of horizontal space on the screen, and makes that breakpoint into a single global variable that can be changed in one place (the new src/assets/scss/_variables.scss file).

Scope
   * Fixes some additional tab bugs, where the dropzones sometimes don't have the correct status. [This was the remaining concern about #377.]
   * Mobile should be fully working at this point.
