### PR TITLE
feat: Allow adding and dropping of OEIS sequence cards

### DIFF
--- a/src/components/SpecimenCard.vue
+++ b/src/components/SpecimenCard.vue
@@ -14,7 +14,9 @@
                 v-if="!permanent"
                 v-on:click.stop="deleteSpecimen"
                 style="padding-right: 15px">
-                <span class="material-icons-sharp" style="user-select: none">
+                <span
+                    class="material-icons-sharp"
+                    style="user-select: none; margin-top: 1ex">
                     delete
                 </span>
             </div>
@@ -85,7 +87,7 @@
         align-items: left;
         text-align: left;
         display: flex;
-        align-items: center;
+        align-items: start;
         justify-content: space-between;
     }
     .card-title {

--- a/src/components/SpecimensGallery.vue
+++ b/src/components/SpecimensGallery.vue
@@ -7,7 +7,7 @@
             :subtitle="specimen.subtitle"
             :lastEdited="specimen.lastEdited"
             @specimenDeleted="removeSpecimen"
-            :permanent="!canDelete" />
+            :permanent="'canDelete' in specimen && !specimen.canDelete" />
     </div>
 </template>
 
@@ -20,12 +20,14 @@
         query: string
         subtitle?: string
         lastEdited?: string
+        canDelete: boolean
     }
 
     const props = defineProps<{
-        canDelete: boolean
         specimens: CardSpecimen[]
     }>()
+
+    const emit = defineEmits(['removeSpecimen'])
 
     const currentSpecimens = ref(props.specimens)
 
@@ -40,6 +42,7 @@
             spec => name === nameOfQuery(spec.query)
         )
         if (index > -1) currentSpecimens.value.splice(index, 1)
+        emit('removeSpecimen', name)
     }
 </script>
 

--- a/src/shared/__tests__/browserCaching.spec.ts
+++ b/src/shared/__tests__/browserCaching.spec.ts
@@ -35,8 +35,8 @@ const mockDate = '06/27/2024, 10:00:00'
 const mockQuery = 'name=Test&viz=ModFill&seq=Random'
 const anotherQuery = 'name=Test&viz=Turtle&seq=Formula'
 const twoSIMs = [
-    {query: mockQuery, date: mockDate},
-    {query: 'name=Another', date: mockDate},
+    {query: mockQuery, date: mockDate, canDelete: true},
+    {query: 'name=Another', date: mockDate, canDelete: true},
 ]
 
 vi.useFakeTimers()
@@ -48,7 +48,7 @@ beforeEach(() => {
 
 describe('SIM functions', () => {
     it('should get the current SIM', () => {
-        const current = {query: mockQuery, date: mockDate}
+        const current = {query: mockQuery, date: mockDate, canDelete: true}
         localStorage.setItem('currentSpecimen', JSON.stringify(current))
         expect(getCurrent()).toEqual(current)
     })
@@ -66,7 +66,9 @@ describe('SIM functions', () => {
         const savedUrls = JSON.parse(
             localStorage.getItem('savedSpecimens') as string
         )
-        expect(savedUrls).toEqual([{query: mockQuery, date: mockDate}])
+        expect(savedUrls).toEqual([
+            {query: mockQuery, date: mockDate, canDelete: true},
+        ])
     })
 
     it('should update an existing specimen', () => {
@@ -75,7 +77,9 @@ describe('SIM functions', () => {
         const savedUrls = JSON.parse(
             localStorage.getItem('savedSpecimens') as string
         )
-        expect(savedUrls).toEqual([{query: anotherQuery, date: mockDate}])
+        expect(savedUrls).toEqual([
+            {query: anotherQuery, date: mockDate, canDelete: true},
+        ])
     })
 
     it('should delete a specimen by name', () => {

--- a/src/shared/defineFeatured.ts
+++ b/src/shared/defineFeatured.ts
@@ -61,7 +61,7 @@ const featuredSIMs = [
 // Is there any reason for us to associate dates with featured specimens? Do
 // we want to record when they were added and show that information somehow?
 const theSIMs = featuredSIMs.map(query => {
-    return {query, date: ''}
+    return {query, date: '', canDelete: false}
 })
 
 export function getFeatured() {

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -37,7 +37,7 @@
                 keyboard_arrow_up
             </span>
         </div>
-        <SpecimensGallery v-if="showSaved" :specimens="saved" canDelete />
+        <SpecimensGallery v-if="showSaved" :specimens="saved" />
     </div>
 </template>
 


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR represents another cleaned portion of the seventh Delft PR (#360). It allows OEIS sequence cards to be added and deleted from the list that is shown in the sequence switcher. It stores this list of "active" OEIS IDs in browser localStorage so that it is persistent across page reloads, tab closures, and the like. This PR still has a completely non-functional OEIS Search bar; instead, it allows adding new OEIS sequences as follows:

Visit a URL for a specimen that uses an OEIS sequence (we should add at least one to the Gallery as well -- any proposals, @katestange ?) Then, go into your browser's URL bar and move your cursor to the end of the URL. You will see the OEIS ID there as part of the URL. Just type your new desired OEIS ID in place of the one that is there, and then visit the resulting URL. With this PR, that new URL will be correctly interpreted, creating a Specimen that uses that sequence, even though the system has not before encountered that OEIS ID. Moreover, the next time you open the Sequence Switcher panel, you will see that new OEIS Sequence card inserted at the beginning of the block of OEIS Sequences.

You can delete OEIS Sequence cards from the OEIS List by clicking on the garbage can icon when the Sequence Switcher is open. Deletion of non-OEIS sequences is not allowed (no icon is shown on those cards). The Gallery and Saved Specimens should work as before (although they deserve testing as the changes in this PR affected their code).

Once this PR is reviewed, improved as needed, and merged, the final planned piece of this Delft PR -- the OEIS search bar -- will be implemented in a following PR.
