### PR TITLE
doc: Harmonize guidance on git, cloning, and other workflows.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,8 @@
 # Contributing to Numberscope
 
-## If you are new to software development and like written guides...
+## If you are new to software development...
 
 Read our [onboarding doc](./doc/onboarding.md).
-
-## If you are new to software development and like videos...
-
-Watch the video series on contributing to Numberscope
-[here](https://www.youtube.com/playlist?list=PLA4KIQBQQRb5ccOdr9v0iLw_fKHup1PkU).
-This video series will introduce you to Numberscope, GitHub, the software we
-use in the Numberscope project, and the workflow for contributing to
-Numberscope.
 
 ## If you are experienced, follow these steps...
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,26 +15,28 @@ Numberscope.
 ## If you are experienced, follow these steps...
 
 (This assumes you're working on the numberscope/frontscope repository, but it
-applies to other repos as well.)
+applies to other repos as well. If you are unfamiliear with basic git
+operations or would like a refresher, we
+[have a guide](./doc/working-with-git-and-github.md#basic-operations).)
 
-1. [Create a fork of the numberscope/frontscope repo](./doc/working-with-git-and-github.md#create-a-fork).
-2. [Clone your fork of numberscope/frontscope](./doc/working-with-git-and-github.md#clone-a-repo).
-3. [Create a branch for your contribution](./doc/working-with-git-and-github.md#create-a-branch).
-4. If you are unfamiliar with them or would like a refresher,
-   [read about basic Git operations](./doc/working-with-git-and-github.md#basic-operations).
-5. [Push your branch to GitHub](./doc/working-with-git-and-github.md#push-a-branch).
-6. [Read Numberscope's coding principles guide](./doc/code-principles.md).
-7. Familiarize yourself with frontscope's
+1. [Clone the numberscope/frontscope repository](./doc/working-with-git-and-github.md#clone-a-repo).
+2. [Create a branch for your contribution](./doc/working-with-git-and-github.md#create-a-branch).
+3. [Read Numberscope's coding principles guide](./doc/code-principles.md).
+4. Familiarize yourself with frontscope's
    [code organization](./doc/code-organization.md) and internal APIs. Some
    information on the latter topic may only be found in comments in the
    relevant sources files, as the documentation project is ongoing. However,
    all such formal documentation currently being generated is gathered in the
    "Internal code and APIs" section of the navigation bar in the
    [online docs](https://numberscope.colorado.edu/doc).
-8. If you are working on a visualizer, read
+5. If you are working on a visualizer, read
    [the doc on making a visualizer](./doc/making-a-visualizer.md).
-9. [Work through Numberscope's pull request checklist](./doc/pull-request-checklist.md).
-10. [Submit a pull request](./doc/working-with-git-and-github.md#submit-a-pull-request).
+6. Implement your changes.
+7. [Create a fork of the numberscope/frontscope repo](./doc/working-with-git-and-github.md#create-a-fork).
+8. [Add your fork as a remote](./doc/working-with-git-and-github.md#add-a-remote).
+9. [Push your branch to GitHub](./doc/working-with-git-and-github.md#push-a-branch).
+10. [Work through Numberscope's pull request checklist](./doc/pull-request-checklist.md).
+11. [Submit a pull request](./doc/working-with-git-and-github.md#submit-a-pull-request).
 
 ## If you need help with Git and contributing...
 
@@ -71,18 +73,19 @@ code is ready to be reviewed by someone at Numberscope, follow these steps:
 
 1. Work through
    [Numberscope's pull request checklist](./doc/pull-request-checklist.md).
-2. Sync your fork with the main numberscope/frontscope repository. The easiest
-   way to do this is to navigate to the page of your fork of
-   numberscope/frontscope and click "Sync fork" (see the picture below).
-   ![A screenshot of the Sync fork option](./doc/img/sync-fork.png) Another
-   way to do this is to
-   [add numberscope/frontscope as a remote](./doc/working-with-git-and-github.md#add-a-remote)
-   and
-   [sync your fork with the remote original](./doc/working-with-git-and-github.md#sync-local-fork-with-remote-original).
+2. Make sure your branch is based on the latest version of the `main` branch
+   from the official repository. The simplest way to do this is to
+   [sync your local clone](./doc/working-with-git-and-github.md#sync-a-local-clone)
+   and if your copy of `main` pulled additional new commits in that process
+   (as opposed to being reported as "already up to date"), then go ahead and
+   [rebase your branch](./doc/working-with-git-and-github.md#rebase-your-branch).
 3. Navigate to the numberscope/frontscope repository. If your fork is synced
    up with the main numberscope/frontscope repository correctly, you should
    see a button (see the image below) that says "Compare & pull request".
    ![A screenshot of the Compare & pull request
 button](./doc/img/compare-and-pull-request.png)
    Click that button, write up some notes for your pull request, and click the
-   "Create pull request button".
+   "Create pull request button". Our
+   [Working with Git guide](./doc/working-with-git-and-github.md) has more
+   details about
+   [submitting a pull request](./doc/working-with-git-and-github.md#submit-a-pull-request).

--- a/doc/gitting-it-right.md
+++ b/doc/gitting-it-right.md
@@ -7,10 +7,10 @@ use this guide to fix your setup.
 Here are the different scenarios you could find yourself in and what to do
 about them.
 
--   1: You have a clone of a Numberscope repository.
+-   1: You have a clone of the official Numberscope repository.
     -   1.A: You haven't made changes.
         -   [Create a fork](./working-with-git-and-github.md#create-a-fork).
-        -   [Clone your fork](./working-with-git-and-github.md#clone-a-repo).
+        -   [Add your fork as a remote](./working-with-git-and-github.md#add-a-remote).
         -   [Create a branch](./working-with-git-and-github.md#create-a-branch).
         -   [Push a branch](./working-with-git-and-github.md#push-a-branch).
         -   Now you are working in your own fork on a dedicated feature
@@ -27,7 +27,6 @@ about them.
             -   [Create a fork](./working-with-git-and-github.md#create-a-fork).
             -   [Add the remote of your fork](./working-with-git-and-github.md#add-a-remote).
             -   [Push the branch to your fork](./working-with-git-and-github.md#push-a-branch).
-            -   [Clone your fork](./working-with-git-and-github.md#clone-a-repo).
             -   Now you are working in your own fork on a dedicated feature
                 branch, congrats! Read about about basic Git operations below
                 and get to work making a cool visualizer!
@@ -37,7 +36,6 @@ about them.
                 -   [Create a fork](./working-with-git-and-github.md#create-a-fork).
                 -   [Add the remote of your fork](./working-with-git-and-github.md#add-a-remote).
                 -   [Push the branch to your fork](./working-with-git-and-github.md#push-a-branch).
-                -   [Clone your fork](./working-with-git-and-github.md#clone-a-repo).
                 -   Now you are working in your own fork on a dedicated
                     feature branch, congrats! Read about about basic Git
                     operations below and get to work making a cool visualizer!
@@ -47,42 +45,37 @@ about them.
                 -   [Create a fork](./working-with-git-and-github.md#create-a-fork).
                 -   [Add the remote of your fork](./working-with-git-and-github.md#add-a-remote).
                 -   [Push the branch to your fork](./working-with-git-and-github.md#push-a-branch).
-                -   [Clone your fork](./working-with-git-and-github.md#clone-a-repo).
                 -   Now you are working in your own fork on a dedicated
                     feature branch, congrats! Read about about basic Git
                     operations below and get to work making a cool visualizer!
                 -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
 -   2: You have a fork of a Numberscope repository.
-    -   2.A: You haven't made changes.
-        -   [Clone your fork](./working-with-git-and-github.md#clone-a-repo)
-            (if you don't have it on your computer yet).
-        -   [Create a branch](./working-with-git-and-github.md#create-a-branch).
-        -   [Push a branch](./working-with-git-and-github.md#push-a-branch).
-        -   Now you are working in your own fork on a dedicated feature
-            branch, congrats! Read about about basic Git operations below and
-            get to work making a cool visualizer!
-        -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
-    -   2.B: You have made changes.
-        -   2.B.1: You are working on the main branch.
-            -   2.B.1.A: You made commits.
-                -   Ask someone at Numberscope for help.
-            -   2.B.1.B: You haven't made commits.
-                -   [Stash your changes](./working-with-git-and-github.md#stash-your-changes).
-                -   [Create a branch](./working-with-git-and-github.md#create-a-branch).
-                -   [Unstash your changes](./working-with-git-and-github.md#unstash-your-changes).
-                -   [Push a branch](./working-with-git-and-github.md#push-a-branch).
-                -   Now you are working in your own fork on a dedicated
-                    feature branch, congrats! Read about about basic Git
-                    operations below and get to work making a cool visualizer!
-                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
-        -   2.B.2: You are working on a different branch.
-            -   2.B.2.A: You have made commits.
-            -   This is the correct setup! Congrats. Feel free to
-                [read about basic Git operations](./working-with-git-and-github.md#basic-operations).
-            -   Keep working in this fashion.
-            -   2.B.2.B: You haven't made commits.
-                -   [Commit your changes](./working-with-git-and-github.md#commit-changes).
-                -   Now you are working in your own fork on a dedicated
-                    feature branch, congrats! Read about about basic Git
-                    operations below and get to work making a cool visualizer!
-                -   [Read about basic Git operations](./working-with-git-and-github.md#basic-operations).
+    -   2.A: You haven't cloned anything.
+        -   [Clone the official Numberscope repository](./working-with-git-and-github.md#clone-a-repo)
+        -   Proceed with 1.A above, except you won't need to create a fork.
+    -   2.B: You cloned the official Numberscope repository.
+        -   Proceed with 1. above, except you won't need to create a fork on
+            any step where it says you should.
+    -   2.C: You cloned your fork.
+        -   Here you have a choice. You can either keep working this way, and
+            add the official Numberscope repository
+            [as a remote](./working-with-git-and-github.md#add-a-remote)
+            (usually named `upstream`). Then in all other tutorials in our
+            documentation where it says `origin` you would use `upstream` and
+            where it says `fork` you would use origin.
+        -   Or, if that is too confusing, you could reconfigure to the
+            recommended situation in which you clone the official repository
+            and then add your fork as a remote. If you haven't made any
+            changes, you can just delete your clone, and start again with 2.A.
+            above.
+        -   If you have made changes, you will have to rearrange your remotes.
+            [Check your remotes](./working-with-git-and-github.md#check-your-remotes).
+            If you have a remote named `fork` that does not point to your fork
+            (unlikely, but check just in case), remove that remote with
+            `git remote remove fork`. Then add your fork
+            [as a remote](./working-with-git-and-github.md#add-a-remote) named
+            `fork`, even if it is already present as origin. Then execute
+            `git remote remove origin`. Finally, add the standard Numberscope
+            repository as a remote named `origin`. Then, you can proceed with
+            1.B. above, except skip any steps that instruct you to create a
+            fork or add a remote.

--- a/doc/making-a-visualizer.md
+++ b/doc/making-a-visualizer.md
@@ -12,8 +12,7 @@ class, which automatically sets up a graphics framework for you to use. Right
 now, there's only one base class available:
 
 -   [`P5Visualizer`](#making-a-p5-visualizer-in-detail) uses the
-    [**p5.js**](https://p5js.org/learn/) library for graphics and user
-    interaction.
+    [**p5.js**](https://p5js.org) library for graphics and user interaction.
 
 For a quick start, copy and modify the template file for your chosen
 framework, which you can find in `src/visualizers-workbench`.

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -7,7 +7,9 @@ contributors.
 
 Unless otherwise specified, all commands we ask you to run are supposed to be
 run in a Terminal emulator using a shell like Bash or Zsh (on Linux and macOS)
-or in Git Bash (on Windows).
+or in Git Bash (on Windows). Anything you have to fill in with the proper
+information for your setup (as opposed to execute verbatim as shown) is
+enclosed in brackets `[]`.
 
 ## Accounts, etc.
 
@@ -16,7 +18,6 @@ Boulder Experimental Mathematics Lab.)
 
 1. If you don't have an account, sign up for [GitHub](https://github.com).
 2. Make sure you've been added to the Numberscope GitHub organization.
-3. Make sure you've been added to the chat app (Slack or Zulip).
 
 ## Setting up your computer for development
 
@@ -63,53 +64,48 @@ Boulder Experimental Mathematics Lab.)
 7. Somewhere on your computer, make a directory where you can keep Numberscope
    code. I like to put a directory called `Code` in my home directory. You can
    call this whatever you want.
-8. If you plan to submit new code to become part of Numberscope at some time
-   in the future, _you must_ "fork" (make your own copy of) the repository:
-    - Go to https://github.com/numberscope/frontscope.
-    - Click the "Fork" button (in the upper right as of this writing) and then
-      follow the instructions GitHub provides. You need to create the fork on
-      your GitHub account. If you just want to run from source it's not
-      strictly necessary, and you can fork later, it's just a little more
-      complicated. If you want your own fork:
+8. Clone the official github repository:
     ```sh
-    cd /path/to/your/code/directory/
-    git clone https://github.com/{your-github-username}/frontscope.git
-    ```
-    Otherwise, if you don't want to fork right now:
-    ```sh
-    cd /path/to/your/code/directory/
+    cd [/path/to/your/code/directory]
     git clone https://github.com/numberscope/frontscope.git
     ```
     If you have trouble, read
     [this doc](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
     or ping someone for help.
-9. If you are going to submit new code, you will also need to run the standard
-   tests of the system with your changes in place, and likely add new tests
-   for your changes. Running tests requires that you have
-   [Docker](https://www.docker.com/) installed on your system. There are many
-   tutorials for installing docker; here are example ones for
-   [Windows](https://docs.docker.com/desktop/install/windows-install/),
-   [Ubuntu Linux](https://linuxconfig.org/quick-docker-installation-on-ubuntu-24-04),
-   and
-   [Mac OS](https://thesecmaster.com/blog/installing-docker-desktop-on-macos).
-10. Go to the newly cloned `frontscope` directory and install the
+9. If you plan to submit new code to become part of Numberscope at some time
+   in the future, _you must_ also "fork" (make your own copy of) the
+   repository:
+    - Go to https://github.com/numberscope/frontscope.
+    - Click the "Fork" button (in the upper right as of this writing) and then
+      follow the instructions GitHub provides. You need to create the fork on
+      your GitHub account.
+10. If you are going to submit new code, you will also need to run the
+    standard tests of the system with your changes in place, and likely add
+    new tests for your changes. Running tests requires that you have
+    [Docker](https://www.docker.com/) installed on your system. There are many
+    tutorials for installing docker; here are example ones for
+    [Windows](https://docs.docker.com/desktop/install/windows-install/),
+    [Ubuntu Linux](https://linuxconfig.org/quick-docker-installation-on-ubuntu-24-04),
+    and
+    [Mac OS](https://thesecmaster.com/blog/installing-docker-desktop-on-macos).
+11. Go to the newly cloned `frontscope` directory and install the
     dependencies:
     ```sh
     cd frontscope
     npm install
     ```
     You need NodeJS installed to do this.
-11. Run the development server (this runs a local copy of Numberscope on your
+12. Run the development server (this runs a local copy of Numberscope on your
     computer so you can interact with the webpage):
     ```sh
     npm run dev
     ```
     This should print a link that you can open in the browser. Open it and see
     if Numberscope seems to be working.
-12. If you plan on contributing code to Numberscope, _you must_ work in your
+13. If you plan on contributing code to Numberscope, _you must_ work in your
     fork on a dedicated feature branch. To learn how to create a branch, see
     [this doc](./working-with-git-and-github.md#create-a-branch).
-13. Finally, before you start changing code, please read
+14. Finally, before you start changing code, please read
     [our docs on submitting a pull request](../CONTRIBUTING.md#submit-a-pull-request).
 
 See [the doc on running from source](./running-from-source.md) for more

--- a/doc/pull-request-checklist.md
+++ b/doc/pull-request-checklist.md
@@ -21,6 +21,10 @@ The PR submitter should:
     unmodified behaviors and newly implemented ones. In particular, run it via
     'npm run dev' and with the browser console open and make sure there are no
     log messages from Numberscope code, warnings, or errors.
+-   Make sure that the branch in the PR is based on the latest commit in the
+    `main` branch in the
+    [official frontscope repository](https://github.com/numberscope/frontscope).
+    If not, [rebase it](./working-with-git-and-github.md#rebase-your-branch).
 -   Read over the reviewer checklist and try to make sure in advance that your
     code is going to proceed as smoothly through the review as possible.
 

--- a/doc/running-from-source.md
+++ b/doc/running-from-source.md
@@ -8,8 +8,8 @@
     "[venv](https://docs.python.org/3/library/venv.html)" module. If any of
     these are not present on your system, install them. It's very likely you
     already have Python, but on Debian/Ubuntu systems, you may well have to
-    install the venv module with a command like `apt install python3.8-venv`
-    (you may have to replace the "3.8" with the version that is currently
+    install the venv module with a command like `apt install python3.11-venv`
+    (you may have to replace the "3.11" with the version that is currently
     running in your installation).
 2.  Clone frontscope to an appropriate location on your computer, and switch
     into the new repository's top-level directory:
@@ -45,10 +45,10 @@
 
 ## Adding to and modifying code
 
-To add to the code, you need to use what's called an "editor" or an
-"integrated development environment" (IDE) to help you enter the commands,
+To add to the code, you will need to use either what's called an "editor" or
+an "integrated development environment" (IDE) to help you enter the commands,
 find any problems, and get your idea working. There are many possibilities for
-these tools, but if you're just starting out, Numberscope recommends an IDE
-called "VSCode" with some additional features added by plugins (Volar and a
-TypeScript Vue module for it). The details for this part of the setup are in
-the [Contributing](visual-studio-code-setup.md) section.
+these tools. One option is an IDE called "VSCode" with some additional
+features added by plugins (Volar and a TypeScript Vue module for it). The
+details for this part of the setup are in
+[a separate page](visual-studio-code-setup.md).

--- a/doc/visual-studio-code-setup.md
+++ b/doc/visual-studio-code-setup.md
@@ -5,7 +5,7 @@ to develop code contributions to Numberscope.
 
 ## VS Code
 
-The recommended IDE consists of [VSCode](https://code.visualstudio.com/) +
+One potential IDE consists of [VSCode](https://code.visualstudio.com/) +
 [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
 (and disable Vetur) +
 [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-typescript-vue-plugin).
@@ -54,5 +54,6 @@ There are of course many other possible editors and IDEs. For example, one can
 use the venerable Emacs editor, which has many packages for highlighting code
 and autoformatting it. Support for the latter that respects Numberscope's
 particular setup is provided by `tools/editor/autoformat.el` in this
-repository. That Emacs package runs source files through the `prettier-eslint`
-formatter (see the following page) every time they are saved in Emacs.
+repository. That Emacs package runs source files through combined `prettier`
+and `eslist` formatting (see the following page) every time they are saved in
+Emacs.

--- a/doc/working-with-git-and-github.md
+++ b/doc/working-with-git-and-github.md
@@ -154,9 +154,9 @@ branch.
 To create a branch and switch to it in one command, first make sure (for
 example, using `git status`) that you are "on" the branch that you want your
 new branch based on. That's sort of the "parent" of the new branch -- in other
-words, the baseline that your branch will represent changes to. Typically for
-working on Numberscope, that will be the `main` branch, so make sure that's
-checked out. Then issue the following command:
+words, the baseline that your branch will record a series of changes to.
+Typically for working on Numberscope, that base will be the `main` branch, so
+make sure that's checked out. Then issue the following command:
 
 ```sh
 git checkout -b [your_new_branch_name]
@@ -228,7 +228,14 @@ Note that if you are working on frontscope and you have installed the standard
 pre-commit actions (as will happen automatically if you execute the usual
 `npm install` when you start working with your clone), then before the commit
 actually occurs, git will run several
-[code integrity checks](./husky-pre-commit.md).
+[code integrity checks](./husky-pre-commit.md). If any of the checks fail,
+creating the commit will be blocked until you have further modified the code
+so that they pass. Making these fixes may be very simple: for example, there
+is a code formatting check, and executing `npm run lint` to run Numberscope's
+standard "prettyprinting" utility may well resolve any problems it is
+reporting. Or the issue may be more involved: one of the unit tests or
+end-to-end tests may have uncovered a bug you've inadvertently introduced. See
+the page on [code tests](./code-tests.md) for more information.
 
 ### Create a fork
 
@@ -336,7 +343,12 @@ commit). Ideally, your branch is not behind main at all; otherwise, maybe some
 of those commits in main might affect the changes you were working on. So if
 you see any commits behind main, you might want to go back to your working
 copy and [sync your clone with the original](#sync-a-local-clone) and then
-rebase your branch on the current version of main.
+rebase your branch on the current version of main. If you submit a PR that is
+not based on the current version of the main branch, you run the risk that it
+may have "merge conflicts" in which both you and a newer version of main have
+modified the same or nearby sections of code. Such merge conflicts will
+prevent your PR from being accepted until the are resolved by rebasing on the
+latest version of main.
 
 In any case, when you are satisfied your branch is ready to submit as a PR,
 you will notice that report of the number of commits ahead or behind main is
@@ -495,10 +507,13 @@ And if you previously stashed any changes, you may want to
 
 A branch works from a specific commit in its parent branch (usually `main`) --
 its like a logbook of all of the changes you've made from that particular
-snapshot of all of the code. Many times for a PR to succeed, the branch must
-be based on the latest commit in `main`. So here's what you do if that
-happens, but your branch is based on an earlier commit in `main` (likely the
-one that was current when you started your work).
+snapshot of all of the code. Often, for a PR to succeed, the branch must be
+based on the latest commit in `main`. So here's what you do if your branch is
+based on an earlier commit in `main` (likely the one that was current when you
+started your work), causing a problem with your PR. You may also want to
+update your branch in this way to make sure it will work with new features
+that have been introduced in main, or just to minimize the obstacles that a PR
+based on it will encounter in the review process.
 
 First, make sure you have synced your clone, as outlined in the previous
 section. Then switch to your branch (with `git checkout [branch_name]`) if

--- a/doc/working-with-git-and-github.md
+++ b/doc/working-with-git-and-github.md
@@ -1,69 +1,319 @@
 # Working with Git and GitHub
 
-Git and GitHub are separate tools, but since there is some overlap when it
-comes to working with them, we describe the Git and GitHub operations relevant
-to Numberscope in the same document.
+Git and GitHub are separate tools: [Git](https://git-scm.com/) is a software
+package for tracking versions of files, often used for source code management,
+and [GitHub](https://github.com) is a commercial website that houses
+"repositories" of versioned files relating to numerous different projects,
+including Numberscope. Since there is some overlap when it comes to working
+with them, though, we describe the Git and GitHub operations relevant to
+Numberscope in this same document.
 
 Contents
 
 -   [Basic operations](#basic-operations)
+    -   [Clone a repo](#clone-a-repo)
+    -   [See what the current git situation is](#display-status)
+    -   [Create a branch](#create-a-branch)
     -   [Add changes](#add-changes)
     -   [Commit changes](#commit-changes)
+    -   [Create a fork](#create-a-fork)
+    -   [Add a remote](#add-a-remote)
+    -   [Push a branch](#push-a-branch)
     -   [Push changes](#push-changes)
     -   [Submit a pull request](#submit-a-pull-request)
 -   [Advanced operations](#advanced-operations)
     -   [Stash your changes](#stash-your-changes)
     -   [Unstash your changes](#unstash-your-changes)
-    -   [Create a branch](#create-a-branch)
-    -   [Push a branch](#push-a-branch)
-    -   [Create a fork](#create-a-fork)
-    -   [Clone a repo](#clone-a-repo)
-    -   [Add a remote](#add-a-remote)
-    -   [Sync local fork with remote original](#sync-local-fork-with-remote-original)
+    -   [Check your remotes](#check-your-remotes)
+    -   [Sync your local clone](#sync-a-local-clone)
+    -   [Rebase your branch](#rebase-your-branch)
 
 ## Basic operations
 
-When using Git, it can be helpful to think of it as photographer who stages
+When using Git, it can be helpful to think of it as a photographer who stages
 your work ("adds" changes), takes a snapshot of it ("commits" changes), and
 stores the photo somewhere safe ("pushes" changes to e.g. GitHub).
 
+### Clone a repo
+
+As described in the
+[onboarding](onboarding.md/#setting-up-your-computer-for-development) page, to
+run the frontscope user interface from its source code and/or to set up for
+making and then submitting changes to the code, you need a copy of all the
+code (and the previous snapshots of it as it developed) on your computer.
+That's called "cloning" the repository.
+
+To do this, make sure you are in a directory on your computer where you are
+comfortable with new subdirectories being created for the project(s) you
+clone. (Of course, you must also have the git software installed.) Then issue
+a command that looks like this:
+
+```sh
+git clone [URI_of_repository]
+```
+
+Note that `[URI_of_repository]` is a placeholder for information that you need
+to fill in, not something you type as is. In general, we will put placeholders
+like this in brackets `[]` so you know what to fill in.
+
+How do you find the URI of the repository you want? In the case it is hosted
+on GitHub, as [frontscope](https://github.com/numberscope/frontscope) is, you
+navigate to the repository page (the one just linked). In the center of the
+page left-to-right and near the top of the page, you will see a bright green
+"Code" button. Click on that button, and it will give you a choice of two
+different URIs to clone the repository with:
+
+1. via HTTPS: This is an unauthenticated connection to the GitHub server, so
+   it is easiest to use for download. However, you cannot submit code changes
+   via an HTTPS URI. That's not a problem for the standard repository for
+   frontscope, because you never submit changes directly to the standard
+   repository. Instead, you will create what's called a "fork" and submit your
+   changes through the fork. So bottom line, we recommend you clone frontscope
+   via its HTTPS URI, which is
+   `https://github.com/numberscope/frontscope.git`.
+2. via SSH: This method of connecting is authenticated and will allow you to
+   upload changes to GitHub. It requires
+   [some setup](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
+   If you have created a clone of frontscope for the purpose of submitting
+   code, you will have to connect to it via an SSH URI, which has the format
+   `git@github.com:[USER]/[REPO].git`.
+
+The "Code" button will also show you a command you could use to clone the
+repository via the "GitHub Command-Line Interface" (or "GitHub CLI"). That
+method requires installing additional software. If you're comfortable with the
+[GitHub CLI](https://cli.github.com/), you can use it for several of the tasks
+on this page, but we won't be going into the details of it here.
+
+To sum this all up for the case of frontscope, we recommend you clone it via
+`git clone https://github.com/numberscope/frontscope.git`.
+
+### Display status
+
+One of the main uses of Git is to facilitate different people working together
+by creating (as it were) different albums of photos of your work (called
+"branches"). The "official" version of
+[frontscope](https://github.com/numberscope/frontscope) (or
+[backscope](https://github.com/numberscope/backscope)) is in the branch called
+"main" in its standard repository (as just linked to). But as we will see, you
+can create new branches for your personal project that involves modifying the
+source code, to make sure that your work doesn't interfere with anyone else's.
+
+But first, you will often need to see what the situation is with your copy of
+frontscope. Let's assume from now on that you have cloned a repository and
+your current directory is within the "working directory" of that clone. (In
+other words, if you have just cloned frontscope, say, then you would need to
+
+`cd frontscope`
+
+before executing any of the commands in the rest of this page.)
+
+OK, so if you are in the working directory of your clone and you want to see
+what the situation is, execute
+
+`git status`
+
+This command will tell you what "branch" of the repository you are currently
+working in, and it will let you know about any differences between the files
+in that working directory and the last snapshot, i.e. "commit", of the
+project.
+
+For example, if you execute `git status` immediately after cloning the
+frontscope repository, you will see:
+
+```text
+On branch main
+Your branch is up to date with 'origin/main'.
+
+nothing to commit, working tree clean
+```
+
+On the other hand, if you had switched to a different branch (more about how
+to do that in a moment), modified one file and created one new one, you might
+see something like this:
+
+```text
+On branch git_docs
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   doc/working-with-git-and-github.md
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	doc/example-documentation.md
+
+no changes added to commit (use "git add" and/or "git commit -a")
+```
+
+Note that we have used a different branch in this example because you should
+_never make changes directly to main_. Always create and work in a different
+branch.
+
+### Create a branch
+
+To create a branch and switch to it in one command, first make sure (for
+example, using `git status`) that you are "on" the branch that you want your
+new branch based on. That's sort of the "parent" of the new branch -- in other
+words, the baseline that your branch will represent changes to. Typically for
+working on Numberscope, that will be the `main` branch, so make sure that's
+checked out. Then issue the following command:
+
+```sh
+git checkout -b [your_new_branch_name]
+```
+
+(At Numberscope we use `snake_case` for branch names.) Once you've done this,
+you have your own "little world" where you can make changes without affecting
+anyone else. Go ahead and modify files or add new ones to get the
+visualization you want!
+
 ### Add changes
 
-To add or "stage" your work for a commit or "snapshot", issue the following
+At some point you will have something new and/or improved working, and you
+will want to get ready to take a snapshot (i.e. make a "commit" to your
+branch) to possibly share or submit to Numberscope, or just as a checkpoint of
+what you have done so far.
+
+For this, you must set the stage for this commit. To "add" one file you have
+been working on to the commit that's about to be made, issue the following
 command:
 
 ```sh
-git add /path/to/file/here
+git add [path/to/file]
 ```
 
-(You should do this command for each file you need to stage.)
+Note that the paths are _relative_ to the top-level directory of the working
+tree, i.e. to the directory named `frontscope` in our case. For example, the
+path of this documentation file is `doc/working-with-git-and-github.md`.
+
+You need to do this for each file you want to stage for this commit; or, see
+the next section for a faster option you can sometimes use.
 
 ### Commit changes
 
-To commit your work or take a "snapshot" of the work, issue the following
-command:
+To take a snapshot of the changed files you have added (i.e, "commit" them),
+issue the following command:
 
 ```sh
-git commit -m "put your commit message here"
+git commit -m "[put your commit message here]"
 ```
+
+As a shortcut, you can add and commit all of the changed files in your working
+tree with
+
+```sh
+git commit -a -m "[put your commit message here]"
+```
+
+Note that this latter command does **not** include any new ("untracked")
+files. Those you must explicitly add with the `git add` command. That's to
+make sure that you don't inadvertently put some temporary junk file you may
+have made into the repository.
 
 You should write your commit messages according to the "semantic commit
 message"
 [guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716).
 
-### Push changes
+If your changes are more extensive than can be comfortably described in a
+single sentence, leave off the `-m "[message]"` part of the command. Then an
+editor will pop up where you can insert the description of your changes, Start
+with one summary line in the semantic commit message format, then skip a line,
+and go into more detail in paragraph(s) below. When you save the message file,
+the commit will complete. In these descriptions, always describe the commit in
+present tense: "This commit implements a frobozzinator", not "This commit
+implemented a frobozzinator". Having them in a uniform format makes the
+eventual git log of changes much easier to read.
 
-Before you are able to do this, you either need to install the
+Note that if you are working on frontscope and you have installed the standard
+pre-commit actions (as will happen automatically if you execute the usual
+`npm install` when you start working with your clone), then before the commit
+actually occurs, git will run several
+[code integrity checks](./husky-pre-commit.md).
+
+### Create a fork
+
+Now that you have a new snapshot of your work, you might like a safe place to
+put it, and/or you may want to submit what you've done for consideration to be
+incorporated into the official Numberscope (that's called "making a pull
+request"). Either way, you'll need to create a "fork" of the frontscope
+repository, since you are not allowed to submit directly to the official
+repository.
+
+Creating a fork of a repository is like creating your own personal copy of the
+entire repository, including all present and past snapshots of the code. It's
+actually essentially the same thing as cloning the repository, except that the
+clone is housed on GitHub's servers rather than on your own local machine. It
+also adds functionality that makes it easier to keep your fork synced with the
+original and submit pull requests.
+
+Note: This is a GitHub operation, not a Git operation. So the first thing you
+will need is a [GitHub account](https://github.com/signup). Once you have that
+and are logged in:
+
+1. Go to the page of the repository you want to fork. For instance, here's a
+   link to the
+   [numberscope/frontscope repository](https://github.com/numberscope/frontscope).
+2. In the upper right corner of the page (as of this writing) there should be
+   a button that says "Fork". Click that button.
+3. Follow the instructions that GitHub provides. Make your GitHub account the
+   owner of the fork.
+
+### Add a remote
+
+Now back on your local machine, you'll want your clone to be able to
+communicate not just with the standard Numberscope repository from which it
+was cloned, but also with your new fork. That's called "adding a remote".
+First, you'll need to grab the **SSH** URI for your fork from its page on
+GitHub, see the [description of URIs](#clone-a-repo) in the section on cloning
+a repository. Then execute the following command
+
+```sh
+git remote add [name_of_remote] [SSH URI for remote]
+```
+
+You can pick whatever name you want to use for this remote; we typically use
+the name "fork" for the fork that we will primarily be submitting ("pushing")
+commits to. So if your user name on GitHub is "somebody", your command might
+look like
+
+```sh
+git remote add fork git@github.com:somebody/frontscope.git
+```
+
+### Push a branch
+
+Now you're finally ready to upload your snapshot, or in git lingo, "push your
+branch". Before you are able to do this, you either need to install the
 [GitHub command line interface (CLI)](https://cli.github.com/) and log in
 using the GitHub CLI or
 [install an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
-To push your changes to a remote version of your repository (i.e. to the
-version on GitHub) or to "store" your photo, issue the following command:
+Presuming that you have not previously pushed anything from your current
+branch to your fork, you will want to create a corresponding branch in that
+remote git repository and set your local branch to "track" or correspond to
+that remote branch. You do this with the following command, that also pushes
+all of the changes on the current branch to the remote:
+
+```sh
+git push -u [name_of_remote] [name_of_branch]
+```
+
+So for example, when first pushing the branch with the changes to this guide,
+the command used was `git push -u fork git_docs`.
+
+### Push changes
+
+If you have already pushed a given branch and set it track the remote branch
+as in the last section, then when you have made further commit(s) that you
+want to upload, just execute:
 
 ```sh
 git push
 ```
+
+Git remembers the remote and branch you want to push to (assuming you used the
+`-u` option earlier) and also what commit(s) were uploaded before, and only
+pushes the new ones.
 
 ### Submit a pull request
 
@@ -71,21 +321,22 @@ Once you have a branch in working order that implements one new feature or
 fixes one bug or otherwise changes Numberscope in a coherent way, and that
 branch is pushed to your fork in the state you want to propose for inclusion
 in Numberscope, the first thing to do is to carefully go through the
-[pull request checklist](pull-request-checklist.md).
+[pull request checklist](pull-request-checklist.md). This is a GitHub
+functionality, not one intrinsic to git.
 
-Presuming that you have satisfied all of the guidelines in that file, it's
-time to submit a pull request (PR). To do so, go to your fork on the GitHub
-website, and select your branch in the dropdown list on near the top left.
-Then in the bar just below that dropdown list, you should see information on
-how your branch compares with the current "main" branch of Numberscope, in
-terms of the number of commits it is "ahead" of main (i.e., has added since
-the last common commit to main) and the number of commits "behind" main (i.e.,
-the number of commits added in main since the last common commit). Ideally,
-your branch is not behind main at all; otherwise, maybe some of those commits
-in main might affect the changes you were working on. So if you see any
-commits behind main, you might want to go back to your working copy and
-[sync your local fork with remote original](#sync-local-fork-with-remote-original)
-and rebase your branch on the current version of main.
+Presuming that you have satisfied all of the guidelines in the checklist file,
+it's time to submit a "pull request" (PR). To do so, go to your fork on the
+GitHub website, and select your branch in the dropdown list on near the top
+left. Then in the bar just below that dropdown list, you should see
+information on how your branch compares with the current "main" branch of
+Numberscope, in terms of the number of commits it is "ahead" of main (i.e.,
+has added since the last common commit to main) and the number of commits
+"behind" main (i.e., the number of commits added in main since the last common
+commit). Ideally, your branch is not behind main at all; otherwise, maybe some
+of those commits in main might affect the changes you were working on. So if
+you see any commits behind main, you might want to go back to your working
+copy and [sync your clone with the original](#sync-a-local-clone) and then
+rebase your branch on the current version of main.
 
 In any case, when you are satisfied your branch is ready to submit as a PR,
 you will notice that report of the number of commits ahead or behind main is
@@ -98,7 +349,7 @@ When all of those changes look right, click the big green button at the top
 right that says "Create Pull Request". This click will take you to the "Open a
 Pull Request" form. (Note that the first time you push a branch to git, the
 response message actually includes a quick direct link to this form; you can
-save that away and use it later, instead of navigating through GitHub's web
+save that link and use it later, instead of navigating through GitHub's web
 interface.)
 
 There are just two boxes you need to fill out on the form to open a pull
@@ -117,7 +368,7 @@ are good to go. If not, replace that placeholder with a more detailed but
 still brief explanation of the reason, purpose, and content of your PR. If it
 takes care of any of the outstanding issues concerning Numberscope listed on
 the GitHub site for Numberscope, include at the bottom on a separate line the
-statement `Resolves #999.` (with the actual issue number in place of 999).
+statement `Resolves #[issue_number].`
 
 When you are happy with the title, description, and changes made in your PR,
 and you agree with the statement that was pre-filled in the description (which
@@ -138,8 +389,15 @@ your ideas. Thank you for submitting your work to Numberscope!
 
 ### Stash your changes
 
-To "stash" your changes (i.e. squirrel them away for later use), issue the
-following command:
+You may be in the middle of working on a project, and decide that you need to
+check out main again to see how something worked originally, or to start on a
+new more urgent project, or something like that. But you may have changed some
+of the files in the working tree, in a way that you want to save, but that is
+not quite ready to turn into a bona fide commit.
+
+In that situation, git has a facility to squirrel away the changes you have
+made so far for later use -- it's called "stashing" the changes. Use the
+command:
 
 ```sh
 git stash
@@ -153,131 +411,181 @@ To unstash your changes, issue the following command:
 git stash apply
 ```
 
-The above command keeps the changes in your stash.
+This command recreates the changes that were previously stashed in your
+working tree, and it also keeps a record of those changes in the stash.
 
-Alternatively, if you wish to discard those changes from the stash, issue the
+Alternatively, if you want to recreate the stashed changes but also
+simultaneously discard them from your stack of stashed changes, issue the
 following command:
 
 ```sh
 git stash pop
 ```
 
-### Create a branch
-
-To create a branch and switch to it in one command, issue the following
-command:
+Finally, if you just want to discard a set of stashed changes _without_
+affecting your working tree, the command is:
 
 ```sh
-git checkout -b your_branch_name_here
+git stash drop
 ```
 
-At Numberscope we use `snake_case` for branch names.
-
-### Push a branch
-
-To create a branch in a remote Git repository and push your changes to that
-branch, issue the following command:
-
-```sh
-git push -u name_of_remote name_of_branch
-```
-
-The name of the remote is most likely `origin` if you are pushing to a fork of
-one of the Numberscope repositories.
-
-### Create a fork
-
-Creating a fork of a repository is like creating your own personal copy of
-that repository. It's basically the same thing as cloning the repository, but
-it creates a GitHub repository associated with your account that mirrors the
-original, at least until you start making changes to your fork. It also adds
-some neat functionality that makes it easier to sync your fork with the
-original and submit pull requests.
-
-Note: This is a GitHub operation, not a Git operation.
-
-1. Go to the page of the repository you want to fork. For instance, if you
-   want to fork the numberscope/frontscope repository, go to
-   https://github.com/numberscope/frontscope.
-2. In the upper right corner of the page (as of this writing) there should be
-   a button that says "Fork". Click that button.
-3. Follow the instructions that GitHub provides. Make your GitHub account the
-   owner of the fork.
-
-### Clone a repo
-
-To clone a Git repository to your computer, issue the following command:
-
-```sh
-git clone https://github.com/some_user_or_org/some_repo.git
-```
-
-GitHub allows you to clone the repo a few different ways:
-
-1. via HTTPS (easiest method, doesn't require setup, has limited
-   functionality, you'll eventually need the
-   [GitHub CLI](https://cli.github.com/))
-2. [via SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
-   (hardest method, requires setup, but ultimately very convenient)
-
-### Add a remote
-
-When you use the operation `git push`, you are pushing your local commit(s) to
-a remote version of your repository.
-
-First, [check to see what remotes you have](#check-your-remotes).
-
-To add a remote version of your repository, issue the following command:
-
-```sh
-git remote add name_of_remote https://someurl.com/somerepo.git
-```
+Be careful -- the difference between "pop" and "drop" is a bit subtle. Both
+get rid of the most recent set of changes in your stash, but "pop" affects
+working tree whereas "drop" throws them away without affecting enything.
 
 ### Check your remotes
 
-To check to see what your "remotes" (where you'll be pushing to) are, issue
-the command below. (The items in <> brackets are placeholders. You shouldn't
-actually have the <> brackets in the real thing.)
+To check to see what your "remotes" (other Git repositories you are set up
+communicate with via push/pull) are, issue the command below.
 
 ```sh
 $ git remote -v
-origin  git@github.com:<org-or-user-name>/<repo-name>.git (fetch)
-origin  git@github.com:<org-or-user-name>/<repo-name>.git (push)
-upstream        git@github.com:<org-or-user-name>/<repo-name>.git (fetch)
-upstream        git@github.com:<org-or-user-name>/<repo-name>.git (push)
 ```
 
-The names "origin" and "upstream" are arbitrary. That being said, they are the
-traditional names. "origin" should be your fork, and "upstream" should be the
-original repository.
+This will show a list that might look something like
 
-### Sync local fork with remote original
-
-See [this SO answer](https://stackoverflow.com/a/7244456).
-
-First, [check your remotes](#check-your-remotes). You should have something
-like what was described in the [check your remotes](#check-your-remotes)
-section of this doc. If not, set origin and/or upstream:
-
-```sh
-git remote add <remote-name> git@github.com:<org-or-user-name>/<repo-name>.git
+```text
+fork	git@github.com:somebody/frontscope.git (fetch)
+fork	git@github.com:somebody/frontscope.git (push)
+origin	https://github.com/numberscope/frontscope.git (fetch)
+origin	https://github.com/numberscope/frontscope.git (push)
 ```
 
-Get the latest changes for upstream:
+The repository you first cloned from will always be named `origin`; any other
+remotes shown will have the names you assigned them when they were addes. The
+name `fork` is just a typical choice for the remote you are generally going to
+push to.
 
-```sh
-git fetch upstream
-```
+### Sync a local clone
 
-Go to your main branch:
+Once you or other people have submitted changes and they have been accepted
+and "merged" into the official `main` branch, the local clone you made on your
+machine will become out of date in terms of its view of the code in the main
+branch. (It won't change its concept of what code is in main until you
+explicitly tell it to download or "pull" the latest commits in main.)
+
+This can be a problem -- you may not want to base a new branch on out-of-date
+code, or a PR you may have submitted may have ended up in a conflicted state
+because it was based on an older version of `main`. Here's how you correct the
+situation.
+
+First, you need to get back onto the main branch in your local working tree.
+If you have any uncommited changes (they would show via
+[`git status`](#display-status)) that you want to save, you should first
+[stash](#stash-your-changes) them. Then execute
 
 ```sh
 git checkout main
+git pull
 ```
 
-Rewrite your main branch so that any commits of yours that aren't already in
-upstream/main are replayed on top of upstream/main:
+This will download all of the changes to the standard `main` branch since you
+created your clone or last pulled `main`, and leave your working tree on the
+main branch with all of the new code. Now you if you want to return to the
+branch you were on, you can execute
 
 ```sh
-git rebase upstream/main
+git checkout [branch-name]
 ```
+
+And if you previously stashed any changes, you may want to
+[unstash them](#unstash-your-changes).
+
+### Rebase your branch
+
+A branch works from a specific commit in its parent branch (usually `main`) --
+its like a logbook of all of the changes you've made from that particular
+snapshot of all of the code. Many times for a PR to succeed, the branch must
+be based on the latest commit in `main`. So here's what you do if that
+happens, but your branch is based on an earlier commit in `main` (likely the
+one that was current when you started your work).
+
+First, make sure you have synced your clone, as outlined in the previous
+section. Then switch to your branch (with `git checkout [branch_name]`) if
+necessary. Make sure that there are no uncommitted changes (by
+[stashing them](#stash-your-changes) or waiting to
+[unstash them](#unstash-your-changes) if you had previously stashed them).
+
+Now you can instruct git to "replay" each of the changes you made in getting
+your branch to where it was, creating new commits along the way. It's as if it
+automatically re-edits each file in just the way you did when you were
+creating your branch, except starting from the current versions of the file.
+The command is:
+
+```sh
+git rebase main
+```
+
+This may go smoothly and simply report "Successfully rebased and updated
+[branch_name]." Or it may hit a "conflict." This conflict can occur when you
+changed a region of a file, and the same or very nearby region of the same
+file has changed in the main branch between when you started and now. Under
+these circumstances, git may not be able to reconstruct how to "re-do" the
+edits you made, starting from the current version of the file. (For example,
+maybe you edited the code for a function that has since been removed, renamed,
+or relocated from the file where it was. Git can't necessarily figure out what
+to do with your changes in that case.)
+
+If git hits such a conflict, rebasing will stop with a report on which files
+are in a conflicted state. If you now look at these files with a text editor,
+you will see that they contain sections that look like:
+
+```text
+<<<<<<< HEAD
+## This is how origin/main changed this file
+=======
+## And this is how your branch changed this file
+>>>>>>> xxxxxxx (Updated doc/working-with-git-and-github.md)
+```
+
+(where xxxxxxx will be a seven-character hexadecimal "hash" identifying the
+particular commit from your branch where these changes occurred).
+
+You need to manually edit this block, removing the `<<<<<<<` line, the
+`=======` line, and the `>>>>>>>` line, and putting the contents in between to
+be the way they "should" be considering both the changes that were made in the
+main branch and in your branch. Sometimes this is easy: maybe `main` fixed a
+typo in a comment and your branch inserted code just before the comment, and
+so you just do both. Other times it is moot: `main` removed a function
+altogether and you changed it in some way that is now irrelevant because the
+function is gone. And other times it is quite tricky: you fixed a bug in some
+function, but main changed its algorithm slightly and now it's not clear if
+the bug is still there or if it is, whether your fix will still work. So you
+may need to consider carefully and do some investigation and testing of your
+new combined code; but most of the time it is pretty straightforward. It's
+just that there aren't any hard-and-fast rules for how to resolve these sorts
+of "overlapping changes" conflicts. If there were, git would just take care of
+them automatically for you.
+
+Anyhow, when you've settled on the best way to resolve the conflict and have
+edited all the conflicted files to have consistent code and have removed the
+conflict markers, you can execute:
+
+```sh
+git rebase --continue
+```
+
+and the process will proceed further, either finishing up and reporting that
+your branch is successfully rebased, or stopping again if further conflicts
+are found.
+
+When the process finishes, you now have locally a version of your changes to
+main that is based on the latest commit from main. It is a sort of rewriting
+of history. If you had already pushed this branch to a remote, your local
+version of the branch is now very different from the remote copy, and you will
+want to force them to be the same again. You can do this with
+
+```sh
+git push -f
+```
+
+(where the `-f` stands for "force"). Finally, your branch is all back in sync
+with main, and, for example, the process of your pull request being reviewed
+can continue.
+
+Note that you will find many tutorials or references concerning Git that
+recommend to use `git merge` to bring your branch up to date with additional
+changes that have occurred in `main` since you branched. In our experience
+working with Numberscope, that has led to more complicated PRs that are more
+difficult to review. Hence, it is our recommendation that you use `git rebase`
+instead of `git merge` for keeping your feature branch up-to-date.


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Resolves https://github.com/numberscope/frontscope/issues/221.

There is still a signifcant amount of repetition/overlap among
CONTRIBUTING.md, and in the doc/ directory, onboarding.md,
running-from-source.md, and working-with-git-and-github.md. I wasn't
sure how we might compartmentalize these, because they are at
different levels of detail and for different audiences.

Since they are all now consistent with each other, I am not too fussed
by the repetitiveness. Maybe it's OK to give potential contributors multiple
places to find the information they need. But if the reviewer has suggestions
about how to reduce the redundancy, I am also open to making more changes.

Note this is a strictly doc-only PR. No operational source code is touched.