### PR TITLE
feat: Default to a featured visualization (not Random ModFill)

### DIFF
--- a/e2e/tests/featured.spec.ts
+++ b/e2e/tests/featured.spec.ts
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test'
-import {parseSpecimenQuery} from '../../src/shared/browserCaching'
+
 import {getFeatured} from '../../src/shared/defineFeatured'
+import {parseSpecimenQuery} from '../../src/shared/specimenEncoding'
 
 const featured = getFeatured()
 test.describe('Featured gallery images', () => {

--- a/e2e/tests/gallery.spec.ts
+++ b/e2e/tests/gallery.spec.ts
@@ -40,7 +40,10 @@ test.describe('Gallery', () => {
         ).toMatch('Mod Fill')
     })
     test('saving a specimen and then deleting it', async ({page}) => {
-        await page.goto('/', {waitUntil: 'domcontentloaded'})
+        // test originally written when the following was the default:
+        await page.goto('/?name=Specimen&viz=ModFill&seq=Random', {
+            waitUntil: 'domcontentloaded',
+        })
         await page.locator('#specimen-bar-desktop #save-button').click()
         await page.goto('/gallery', {waitUntil: 'domcontentloaded'})
 

--- a/e2e/tests/idiot.spec.ts
+++ b/e2e/tests/idiot.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test'
 
-import {specimenQuery} from '../../src/shared/browserCaching'
+import {specimenQuery} from '../../src/shared/specimenEncoding'
 
 // These are tests in the spirit of
 // https://github.com/numberscope/frontscope/issues/113, i.e.

--- a/e2e/tests/scope.spec.ts
+++ b/e2e/tests/scope.spec.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test'
-import {parseSpecimenQuery} from '../../src/shared/browserCaching'
+
+import {parseSpecimenQuery} from '../../src/shared/specimenEncoding'
 
 test.beforeEach(async ({page}) => {
     await page.goto('/', {waitUntil: 'domcontentloaded'})
@@ -99,6 +100,10 @@ test.describe('Scope', () => {
         ).toBeGreaterThan(375)
     })
     test('Changing a parameter', async ({page}) => {
+        // test originally written when the following was the default:
+        await page.goto('/?name=Specimen&viz=ModFill&seq=Random', {
+            waitUntil: 'domcontentloaded',
+        })
         const oldURL = page.url()
 
         await page.locator('#modDimension').fill('100')

--- a/e2e/tests/stress.spec.ts
+++ b/e2e/tests/stress.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test'
 
-import {specimenQuery} from '../../src/shared/browserCaching'
+import {specimenQuery} from '../../src/shared/specimenEncoding'
 
 // These are non-snapshot tests that we know to be somewhat or very
 // challenging to Numberscope. Once sequences that are here pass, they

--- a/e2e/tests/transversal.spec.ts
+++ b/e2e/tests/transversal.spec.ts
@@ -1,7 +1,8 @@
-import {test, expect} from '@playwright/test'
-import {specimenQuery} from '../../src/shared/browserCaching'
-import {math} from '../../src/shared/math'
 import fs from 'fs'
+import {test, expect} from '@playwright/test'
+
+import {math} from '../../src/shared/math'
+import {specimenQuery} from '../../src/shared/specimenEncoding'
 
 // The idea here is to take a collection of challenging sequences, and
 // make sure that we try each sequence with at least two visualizers, and

--- a/src/components/SwitcherModal.vue
+++ b/src/components/SwitcherModal.vue
@@ -61,17 +61,19 @@ click on the trash button on its preview card.
 </template>
 
 <script setup lang="ts">
+    import {ref, onMounted} from 'vue'
+    import type {PropType, UnwrapNestedRefs} from 'vue'
+
     import SpecimensGallery from './SpecimensGallery.vue'
     import OEISbar from './OEISbar.vue'
     import type {CardSpecimen} from './SpecimensGallery.vue'
-    import {seqMODULES, enableOEIS, disableOEIS} from '../sequences/sequences'
-    import vizMODULES from '../visualizers/visualizers'
-    import {specimenQuery, getIDs} from '../shared/browserCaching'
-    import {isMobile} from '../shared/layoutUtilities'
-    import {Specimen} from '../shared/Specimen'
 
-    import {ref, onMounted} from 'vue'
-    import type {PropType, UnwrapNestedRefs} from 'vue'
+    import {seqMODULES, enableOEIS, disableOEIS} from '@/sequences/sequences'
+    import {getIDs} from '@/shared/browserCaching'
+    import {isMobile} from '@/shared/layoutUtilities'
+    import {Specimen} from '@/shared/Specimen'
+    import {specimenQuery} from '@/shared/specimenEncoding'
+    import vizMODULES from '@/visualizers/visualizers'
 
     function descriptions(
         mods: {[key: string]: {description: string}},

--- a/src/shared/Paramable.ts
+++ b/src/shared/Paramable.ts
@@ -1,8 +1,8 @@
-import {seqKey} from './browserCaching'
 import {hasField, makeStringFields} from './fields'
 import type {StringFields, GenericStringFields} from './fields'
 import typeFunctions, {ParamType} from './ParamType'
 import type {RealizedParamType} from './ParamType'
+import {seqKey} from './specimenEncoding'
 import {ValidationStatus} from './ValidationStatus'
 
 /**

--- a/src/shared/Specimen.ts
+++ b/src/shared/Specimen.ts
@@ -1,5 +1,5 @@
-import {specimenQuery, parseSpecimenQuery} from './browserCaching'
 import {math} from './math'
+import {specimenQuery, parseSpecimenQuery} from './specimenEncoding'
 
 import type {SequenceInterface} from '@/sequences/SequenceInterface'
 import {produceSequence} from '@/sequences/sequences'

--- a/src/shared/browserCaching.ts
+++ b/src/shared/browserCaching.ts
@@ -1,3 +1,7 @@
+import {getFeatured} from './defineFeatured'
+import {math} from './math'
+import {specimenQuery} from './specimenEncoding'
+
 /* This file is responsible for all of the state of Numberscope that is kept
    in browser localStorage. Currently that consists of a collection of saved
    Specimens, and the list of IDs of OEIS sequences that will be shown in
@@ -35,122 +39,12 @@ function getCurrentDate(): string {
     return new Intl.DateTimeFormat('en-US', options).format(currentDate)
 }
 
-// QUERY ENCODING OF SPECIMENS
-const vizKey = 'viz'
-export const seqKey = 'seq'
-type QuerySpec = {
-    name: string
-    visualizerKind: string
-    sequenceKind: string
-    visualizerQuery: string
-    sequenceQuery: string
-}
-/**
- * Generates a URL query string from the information specifying a specimen.
- *
- * @param {string | QuerySpec} nameOrSpec
- *     The name of the specimen, or an object with key `name` and all of
- *     the other argument names as keys, in which case the other arguments
- *     are taken from this object instead
- * @param {string} visualizerKind  The kind of Visualizer
- * @param {string} sequenceKind  The kind of Sequence
- * @param {string?} visualizerQuery  Optional visualizer query parameter string
- * @param {string?} sequenceQuery  Optional sequence query parameter string
- * @return {string} the URL query string encoding of the parameter
- */
-export function specimenQuery(
-    nameOrSpec: string | QuerySpec,
-    visualizerKind?: string,
-    sequenceKind?: string,
-    visualizerQuery?: string,
-    sequenceQuery?: string
-): string {
-    let name = ''
-    if (!visualizerKind) {
-        // Only one arg, must be query
-        const spec = nameOrSpec as QuerySpec
-        name = spec.name
-        visualizerKind = spec.visualizerKind
-        sequenceKind = spec.sequenceKind
-        visualizerQuery = spec.visualizerQuery
-        sequenceQuery = spec.sequenceQuery
-    } else {
-        name = nameOrSpec as string
-    }
-    if (!sequenceKind) return ''
-    const leadQuery = new URLSearchParams({
-        name,
-        [vizKey]: visualizerKind,
-    })
-    const sepQuery = new URLSearchParams({[seqKey]: sequenceKind})
-    const queries = [leadQuery.toString()]
-    if (visualizerQuery) queries.push(visualizerQuery)
-    queries.push(sepQuery.toString())
-    if (sequenceQuery) queries.push(sequenceQuery)
-    return queries.join('&')
-}
-/**
- * Splits a URL query string for a specimen into its constituent parts
- * Returns an object with keys `name`, `visualizerKind`, `specimenKind`,
- * `visualizerQuery`, and `sequenceQuery`, corresponding to the five
- * arguments of specimenQuery(). I.e., this function inverts specimenQuery().
- *
- * @param {string} query  A URL query string encoding a specimen
- * @return {object} representation of components as decribed above.
- */
-export function parseSpecimenQuery(query: string) {
-    const params = new URLSearchParams(query)
-    const name = params.get('name') || 'Error: Unknown Name'
-    // We never insert a frame count in queries we generate, but
-    // we do parse it out in case it was specified, e.g. to make
-    // tests reproducible
-    const frames = parseFloat(params.get('frames') || 'Infinity')
-    // Similarly, we never insert a seed, but parse it in case it
-    // was specified
-    const seed = params.get('randomSeed') || null
-    const visualizerKind =
-        params.get(vizKey) || 'Error: No visualizer kind specified'
-    const sequenceKind =
-        params.get(seqKey) || 'Error: No sequence kind specified'
-    const vizPat = new RegExp(`&${vizKey}=[^&]*&`, 'd')
-    const seqPat = new RegExp(`&${seqKey}=[^&]*&?`, 'd')
-    let visualizerQuery = ''
-    let sequenceQuery = ''
-    const vizMatch = query.match(vizPat)
-    const seqMatch = query.match(seqPat)
-    if (vizMatch?.indices && seqMatch?.index && seqMatch?.indices) {
-        const firstAfterViz = vizMatch.indices[0][1]
-        if (seqMatch.index > firstAfterViz)
-            visualizerQuery = query.substring(firstAfterViz, seqMatch.index)
-        const firstAfterSeq = seqMatch.indices[0][1]
-        if (firstAfterSeq < query.length)
-            sequenceQuery = query.substring(firstAfterSeq)
-    }
-    return {
-        name,
-        frames,
-        seed,
-        visualizerKind,
-        sequenceKind,
-        visualizerQuery,
-        sequenceQuery,
-    }
-}
-
 // MEMORY RELATED HELPER FUNCTIONS AND VARIABLES
 
 // Keys of where the SIMs and IDs are saved (are arbitrary)
 const cacheKey = 'savedSpecimens'
 const currentKey = 'currentSpecimen'
 const idKey = 'activeIDs'
-
-// The default specimen
-// Will be displayed when the user visits the website for the first time
-export const defaultQuery = specimenQuery(
-    'Default Specimen',
-    'ModFill',
-    'Random'
-)
 
 // For backward compatibility:
 function newSIMfromOld(oldSim: {date: string; en64: string}): SIM {
@@ -252,7 +146,7 @@ export function getCurrent(): SIM {
         if ('en64' in data) return newSIMfromOld(data)
     }
 
-    return {query: defaultQuery, date: '', canDelete: true}
+    return math.pickRandom(getFeatured())
 }
 
 // Helper type for updateCurrent

--- a/src/shared/defineFeatured.ts
+++ b/src/shared/defineFeatured.ts
@@ -1,4 +1,4 @@
-import {specimenQuery} from './browserCaching'
+import {specimenQuery} from './specimenEncoding'
 
 // Encodings of the featured specimens
 

--- a/src/shared/specimenEncoding.ts
+++ b/src/shared/specimenEncoding.ts
@@ -1,0 +1,106 @@
+/* This file defines how specimens are encoded into strings, and how
+   strings are decoded into the information needed to create a specimen.
+   At the moment (and likely permanently), the encodes are URL query
+   parameter strings.
+*/
+
+const vizKey = 'viz'
+export const seqKey = 'seq'
+type QuerySpec = {
+    name: string
+    visualizerKind: string
+    sequenceKind: string
+    visualizerQuery: string
+    sequenceQuery: string
+}
+/**
+ * Generates a URL query string from the information specifying a specimen.
+ *
+ * @param {string | QuerySpec} nameOrSpec
+ *     The name of the specimen, or an object with key `name` and all of
+ *     the other argument names as keys, in which case the other arguments
+ *     are taken from this object instead
+ * @param {string} visualizerKind  The kind of Visualizer
+ * @param {string} sequenceKind  The kind of Sequence
+ * @param {string?} visualizerQuery  Optional visualizer query parameter string
+ * @param {string?} sequenceQuery  Optional sequence query parameter string
+ * @return {string} the URL query string encoding of the parameter
+ */
+export function specimenQuery(
+    nameOrSpec: string | QuerySpec,
+    visualizerKind?: string,
+    sequenceKind?: string,
+    visualizerQuery?: string,
+    sequenceQuery?: string
+): string {
+    let name = ''
+    if (!visualizerKind) {
+        // Only one arg, must be query
+        const spec = nameOrSpec as QuerySpec
+        name = spec.name
+        visualizerKind = spec.visualizerKind
+        sequenceKind = spec.sequenceKind
+        visualizerQuery = spec.visualizerQuery
+        sequenceQuery = spec.sequenceQuery
+    } else {
+        name = nameOrSpec as string
+    }
+    if (!sequenceKind) return ''
+    const leadQuery = new URLSearchParams({
+        name,
+        [vizKey]: visualizerKind,
+    })
+    const sepQuery = new URLSearchParams({[seqKey]: sequenceKind})
+    const queries = [leadQuery.toString()]
+    if (visualizerQuery) queries.push(visualizerQuery)
+    queries.push(sepQuery.toString())
+    if (sequenceQuery) queries.push(sequenceQuery)
+    return queries.join('&')
+}
+/**
+ * Splits a URL query string for a specimen into its constituent parts
+ * Returns an object with keys `name`, `visualizerKind`, `specimenKind`,
+ * `visualizerQuery`, and `sequenceQuery`, corresponding to the five
+ * arguments of specimenQuery(). I.e., this function inverts specimenQuery().
+ *
+ * @param {string} query  A URL query string encoding a specimen
+ * @return {object} representation of components as decribed above.
+ */
+export function parseSpecimenQuery(query: string) {
+    const params = new URLSearchParams(query)
+    const name = params.get('name') || 'Error: Unknown Name'
+    // We never insert a frame count in queries we generate, but
+    // we do parse it out in case it was specified, e.g. to make
+    // tests reproducible
+    const frames = parseFloat(params.get('frames') || 'Infinity')
+    // Similarly, we never insert a seed, but parse it in case it
+    // was specified
+    const seed = params.get('randomSeed') || null
+    const visualizerKind =
+        params.get(vizKey) || 'Error: No visualizer kind specified'
+    const sequenceKind =
+        params.get(seqKey) || 'Error: No sequence kind specified'
+    const vizPat = new RegExp(`&${vizKey}=[^&]*&`, 'd')
+    const seqPat = new RegExp(`&${seqKey}=[^&]*&?`, 'd')
+    let visualizerQuery = ''
+    let sequenceQuery = ''
+    const vizMatch = query.match(vizPat)
+    const seqMatch = query.match(seqPat)
+    if (vizMatch?.indices && seqMatch?.index && seqMatch?.indices) {
+        const firstAfterViz = vizMatch.indices[0][1]
+        if (seqMatch.index > firstAfterViz)
+            visualizerQuery = query.substring(firstAfterViz, seqMatch.index)
+        const firstAfterSeq = seqMatch.indices[0][1]
+        if (firstAfterSeq < query.length)
+            sequenceQuery = query.substring(firstAfterSeq)
+    }
+    return {
+        name,
+        frames,
+        seed,
+        visualizerKind,
+        sequenceKind,
+        visualizerQuery,
+        sequenceQuery,
+    }
+}


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Resolves #426.

Note that specimenQuery() and parseSpecimenQuery() had to move out of src/shared/browserCaching.ts to their own new file, to avoid circular inclusions.
