### PR TITLE
ui: Move parameter descriptions just below their entry boxes

### DIFF
--- a/src/components/ParamField.vue
+++ b/src/components/ParamField.vue
@@ -1,10 +1,5 @@
 <template>
     <div style="margin-bottom: 32px">
-        <p
-            v-if="!param.hideDescription && param.description"
-            class="param-description">
-            {{ param.description }}
-        </p>
         <div class="input-container">
             <label>
                 {{ param.displayName }}
@@ -50,6 +45,11 @@
                 <div class="desc-tooltip-text">{{ param.description }}</div>
             </div>
         </div>
+        <p
+            v-if="!param.hideDescription && param.description"
+            class="param-description">
+            {{ param.description }}
+        </p>
         <p v-for="error in status.errors" :key="error" class="error-message">
             {{ error }}
         </p>

--- a/src/visualizers/Turtle.ts
+++ b/src/visualizers/Turtle.ts
@@ -226,7 +226,7 @@ in pixels.
         visibleDependency: 'pathLook',
         visibleValue: true,
     },
-    /**
+    /** md
 - Background color: The color of the visualizer canvas.
      **/
     bgColor: {
@@ -237,7 +237,7 @@ in pixels.
         visibleDependency: 'pathLook',
         visibleValue: true,
     },
-    /**
+    /** md
 - Stroke color: The color used for drawing the path.
      **/
     strokeColor: {


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Resolves #432.

Also includes last two Turtle parameters into its user guide page, that accidentally got left out of #404.
