### PR TITLE
fix: Ensure back button updates visualization

### DIFF
--- a/e2e/tests/scope.spec.ts
+++ b/e2e/tests/scope.spec.ts
@@ -151,14 +151,19 @@ test.describe('Scope: on Random Modfill', () => {
         await page.evaluate(() => localStorage.clear())
     })
 
-    test('Changing a parameter', async ({page}) => {
+    test('Changing a parameter, then using back button', async ({page}) => {
         const oldURL = page.url()
 
         await page.locator('#modDimension').fill('100')
         await expect(page.locator('#modDimension')).toHaveValue('100')
 
         await expect(page.url()).not.toEqual(oldURL)
+
+        await page.goBack({waitUntil: 'domcontentloaded'})
+        await expect(page.url()).toEqual(oldURL)
+        await expect(page.locator('#modDimension')).toHaveValue('10')
     })
+
     test('refreshing the specimen', async ({page}) => {
         const oldCanvas = await page.locator('#canvas-container canvas')
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="container">
         <main>
-            <Suspense><RouterView /></Suspense>
+            <RouterView />
         </main>
     </div>
 </template>

--- a/src/components/SpecimenCard.vue
+++ b/src/components/SpecimenCard.vue
@@ -47,7 +47,7 @@
                 },
             },
         },
-        emits: ['specimenDeleted'],
+        emits: ['specimenDeleted', 'selected'],
         data() {
             return {specimenName: '', useSub: ''}
         },
@@ -58,9 +58,8 @@
         },
         methods: {
             openSpecimen() {
-                this.$router
-                    .push(`/?${this.query}`)
-                    .then(_value => window.location.reload())
+                this.$router.push(`/?${this.query}`)
+                this.$emit('selected')
             },
             deleteSpecimen() {
                 deleteSpecimen(this.specimenName)

--- a/src/components/SpecimensGallery.vue
+++ b/src/components/SpecimensGallery.vue
@@ -7,6 +7,7 @@
             :subtitle="specimen.subtitle"
             :last-edited="specimen.lastEdited"
             :permanent="'canDelete' in specimen && !specimen.canDelete"
+            @selected="emit('selected')"
             @specimen-deleted="removeSpecimen" />
     </div>
 </template>
@@ -29,7 +30,7 @@
         specimens: CardSpecimen[]
     }>()
 
-    const emit = defineEmits(['removeSpecimen'])
+    const emit = defineEmits(['removeSpecimen', 'selected'])
 
     const currentSpecimens = ref(props.specimens)
 

--- a/src/components/SwitcherModal.vue
+++ b/src/components/SwitcherModal.vue
@@ -52,7 +52,8 @@ click on the trash button on its preview card.
                         <SpecimensGallery
                             class="results"
                             :specimens="cards"
-                            @remove-specimen="deleteModule" />
+                            @remove-specimen="deleteModule"
+                            @selected="emit('close')" />
                     </div>
                 </div>
             </div>

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -79,7 +79,7 @@
         modifiers: [
             // keep the edges inside the screen
             interact.modifiers.restrictEdges({
-                outer: '#speciment-container',
+                outer: '#specimen-container',
             }),
 
             // minimum size

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -7,20 +7,26 @@
     import {Specimen} from '@/shared/Specimen'
 
     const canvasContainer = ref<HTMLDivElement | null>(null)
+    let savedContainer: HTMLDivElement | null = null
     let specimen: Specimen | undefined = undefined
     const props = defineProps<{query: string}>()
 
     onMounted(async () => {
         specimen = await Specimen.fromQuery(props.query)
         if (!(canvasContainer.value instanceof HTMLElement)) return
-        specimen.setup(canvasContainer.value)
+        savedContainer = canvasContainer.value
+        specimen.setup(savedContainer)
         setTimeout(() => specimen?.visualizer.stop(), 4000)
     })
 
     onUnmounted(() => {
-        if (!specimen || !(canvasContainer.value instanceof HTMLElement))
+        // Turns out canvasContainer has already been de-refed
+        // by the time we get here, so we can't depart using that.
+        // Hence the need for savedContainer, unfortunately.
+        if (!specimen || !(savedContainer instanceof HTMLElement)) {
             return
-        specimen.visualizer.depart(canvasContainer.value)
+        }
+        specimen.visualizer.depart(savedContainer)
     })
 </script>
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,8 @@
-import Scope from '../views/Scope.vue'
-import Gallery from '../views/Gallery.vue'
 import {createRouter, createWebHistory} from 'vue-router'
+
+import {getCurrent} from '@/shared/browserCaching'
+import Scope from '@/views/Scope.vue'
+import Gallery from '@/views/Gallery.vue'
 
 const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
@@ -16,6 +18,11 @@ const router = createRouter({
             component: Gallery,
         },
     ],
+})
+
+// Establish the default specimen if none is supplied via a query:
+router.beforeEach(to => {
+    if (to.fullPath === '/') return `/?${getCurrent().query}`
 })
 
 export default router

--- a/src/shared/__tests__/specimen.spec.ts
+++ b/src/shared/__tests__/specimen.spec.ts
@@ -1,9 +1,12 @@
-import {Specimen} from '../Specimen'
 import {describe, it, expect} from 'vitest'
+
+import {Specimen} from '../Specimen'
+import {specimenQuery} from '../specimenEncoding'
 
 describe('url', () => {
     it('remains the same when re-encoding', async () => {
-        const specimen1 = new Specimen('Hello', 'ModFill', 'Random')
+        const specimen1 = new Specimen()
+        specimen1.loadQuery(specimenQuery('Hello', 'ModFill', 'Random'))
         specimen1.visualizer.tentativeValues.modDimension = '50'
         const enc1 = specimen1.query
 

--- a/src/shared/math.ts
+++ b/src/shared/math.ts
@@ -285,7 +285,6 @@ export class MathFormula {
                     (node, path) => math.isSymbolNode(node) && path !== 'fn'
                 )
                 .map(node => (node as SymbolNode).name)
-            console.log('FOUND', this.inputs)
             this.evaluator = parsetree.compile()
         }
     }

--- a/src/visualizers/Differences.ts
+++ b/src/visualizers/Differences.ts
@@ -46,18 +46,23 @@ class Differences extends P5Visualizer(paramDesc) {
         'Produces a table of differences '
         + 'between consecutive entries, potentially iterated several times'
 
-    useTerms = 40n // Typically more than enough to fill screen
-    useLevels = 0n
+    // Dummy values, actually computed in setup()
+    useTerms = -1n
+    useLevels = -1n
 
     setup() {
         super.setup()
+        this.useTerms = 40n // Typically more than enough to fill screen
         if (this.seq.last < this.seq.first + this.useTerms - 1n) {
             this.useTerms = BigInt(this.seq.last) - this.seq.first + 1n
         }
         this.useLevels = this.levels
         if (this.useLevels > this.useTerms) {
             this.useLevels = this.useTerms
-            // TODO: Should really warn about this situation
+            // TODO IN OVERHAUL: Should really warn about this situation
+            // So some of this code will have to move into checkParameters
+            // maybe there will need to be a common helper function called
+            // from both there and here.
         }
     }
 


### PR DESCRIPTION
  Prior to this change, the browser 'back' button would always update the
  URL, but the visualization would typically not change if you were going
  from one scope URL (`/?name=Blah&...`) to another.

  This PR remedies the situation by watching for route changes in the
  Scope view, and reloading the new visualizer and sequence **into** the
  specimen already being viewed. Implementing this tactic requires the
  ability to completely change the sequence and visualizer of a specimen,
  which previously did not exist.

  The change also enables delaying specimen initialization from Vue setup()
  time to just before the component is mounted. As a result, the Vue setup
  is not asynchronous, so the experimental Vue `<Suspense>` tag is no longer
  needed.

  Adds a test that the back button actually took effect, to the existing
  test that changes a parameter. (The extended test definitely failed in
  ui2 prior to this PR.)

  Uses the router to redirect from an empty URL to the last-viewed specimen,
  rather than the Scope component; this change avoids reloading that specimen
  when the URL is updated to reflect what specimen is being viewed.

  Finally, fixes a small previously-existing bug in which the Differences
  visualizer could never display more terms than were available in its last
  parameter settings, even if you changed the parameters to make more
  terms available.

  Resolves #414.

  Given the large number of internal changes to Specimen.ts, please
  in review do play with a veriety of visualizations to make sure all seems
  to be working well.

<hr/>

By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.
