### PR TITLE
fix: Don't attempt to factor 'unsafe' integers

### DIFF
--- a/src/sequences/__tests__/simpleFactor.spec.ts
+++ b/src/sequences/__tests__/simpleFactor.spec.ts
@@ -1,0 +1,27 @@
+import {describe, it, expect} from 'vitest'
+
+import simpleFactor from '../simpleFactor'
+
+describe('simpleFactor', () => {
+    it('should factor the product of two 3-digit primes', () => {
+        expect(simpleFactor(991n * 997n)).toEqual([
+            [991n, 1n],
+            [997n, 1n],
+        ])
+    })
+
+    it.todo('should factor the product of two 4-digit primes', () => {
+        expect(simpleFactor(1009n * 1013n)).toEqual([
+            [1009n, 1n],
+            [1013n, 1n],
+        ])
+    })
+
+    it('should not report that 2^54 - 1 is even', () => {
+        const bit54 = BigInt(2 ** 54 - 1)
+        const factorization = simpleFactor(bit54)
+        if (factorization !== null) {
+            expect(factorization[0][0]).not.toEqual(2n)
+        }
+    })
+})

--- a/src/sequences/simpleFactor.ts
+++ b/src/sequences/simpleFactor.ts
@@ -45,6 +45,11 @@ export default function simpleFactor(v: bigint): Factorization {
         v = -v
         factors.push([-1n, 1n])
     }
+    // don't report any factorizations of "unsafe" integers since we can't
+    // be sure it didn't come from a number => bigint conversion that created
+    // apparent accuracy where there was none.  TODO: when we upgrade to
+    // bigints in formulas, revisit this.
+    if (v > Number.MAX_SAFE_INTEGER) return null
     for (const p of smallPrimes) {
         let power = 0n
         // OK to use % since all we care about is divisibility:


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Resolves those portions of #475 that can be dealt with before upgrading to mathjs 13 and bigint within Formulas.
That issue #475 will need to be revised and adjusted to beta milestone once this PR is merged.

Also adds at least rudimentary tests for simpleFactor, including one that won't pass until we make it less "simple".