### PR TITLE
fix: Don't stretch SpecimenCards when only one row

### DIFF
--- a/src/components/SwitcherModal.vue
+++ b/src/components/SwitcherModal.vue
@@ -293,6 +293,7 @@ click on the trash button on its preview card.
 
     .results {
         display: flex;
+        height: min-content;
         flex-wrap: wrap;
         overflow: auto;
         flex: 1;


### PR DESCRIPTION
  Resolves #479.

By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.
