### PR TITLE
fix: Drag into sidebar always docks into an empty zone

### DIFF
--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -25,6 +25,7 @@
     import interact from 'interactjs'
     import type {InteractEvent} from '@interactjs/types'
     import {
+        maybeClearDropzoneContainer,
         positionAndSizeTab,
         positionAndSizeAllTabs,
         selectTab,
@@ -258,8 +259,7 @@
             )
             const dropzoneContainer = dropzone?.parentElement?.parentElement
             if (
-                tab instanceof HTMLElement
-                && dropzone instanceof HTMLElement
+                dropzone instanceof HTMLElement
                 && dropzoneContainer instanceof HTMLElement
                 && tab.classList.contains('docked')
             ) {
@@ -267,13 +267,7 @@
                 dropzone.classList.add('empty')
                 tab.classList.remove('docked')
                 tab.setAttribute('docked', 'none')
-                // if both dropzones are empty,
-                // make the dropzone container empty aswell
-                if (
-                    dropzoneContainer.querySelectorAll('.empty').length == 2
-                ) {
-                    dropzoneContainer.classList.add('empty')
-                }
+                maybeClearDropzoneContainer(dropzoneContainer)
             }
             return
         }

--- a/src/sequences/Formula.ts
+++ b/src/sequences/Formula.ts
@@ -2,7 +2,7 @@ import {Cached} from './Cached'
 import {SequenceExportModule} from './SequenceInterface'
 
 import {math, MathFormula} from '@/shared/math'
-import type {GenericParamDescription} from '@/shared/Paramable'
+import type {ParamValues, GenericParamDescription} from '@/shared/Paramable'
 import {ParamType} from '@/shared/ParamType'
 
 /** md
@@ -112,6 +112,11 @@ class Formula extends Cached(paramDesc) {
     initialize(): void {
         super.initialize()
         this.name = formulaMark + this.formula.source
+    }
+
+    assignParameters(realized?: ParamValues<GenericParamDescription>) {
+        this.nErrors = 0
+        return super.assignParameters(realized)
     }
 
     calculate(n: bigint) {

--- a/src/sequences/Formula.ts
+++ b/src/sequences/Formula.ts
@@ -2,7 +2,7 @@ import {Cached} from './Cached'
 import {SequenceExportModule} from './SequenceInterface'
 
 import {math, MathFormula} from '@/shared/math'
-import type {ParamValues, GenericParamDescription} from '@/shared/Paramable'
+import type {GenericParamDescription} from '@/shared/Paramable'
 import {ParamType} from '@/shared/ParamType'
 
 /** md
@@ -112,11 +112,6 @@ class Formula extends Cached(paramDesc) {
     initialize(): void {
         super.initialize()
         this.name = formulaMark + this.formula.source
-    }
-
-    assignParameters(realized?: ParamValues<GenericParamDescription>) {
-        this.nErrors = 0
-        return super.assignParameters(realized)
     }
 
     calculate(n: bigint) {


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Prior to this PR, dragging a tab on top of a docked one would leave
  it floating over the docked tab. Moreover, if the empty zone in the
  sidebar was less than half the size of the tab being dragged, it would
  be impossible to dock the dragged tab at all.

  Now any drag into a sidebar with at least one empty zone results in
  a docking to the targeted zone if it is empty, or the first empty zone
  if not.

  Resolves https://github.com/numberscope/frontscope/issues/431.

  Note that this PR does not at the moment implement any resizing.
  There is resizing described in issue https://github.com/numberscope/frontscope/issues/431. However, now that this is
  working smoothly, it is making perfect visual sense to me that the
  dragged tab fits itself into the remaining empty space, leaving the
  already-docked tab alone, and in fact, this behavior seems to me
  preferable to what's described in https://github.com/numberscope/frontscope/issues/431. But if there remains a clear
  desire for the resizing as described in the issue, that can be
  implemented. Just let me know.

OK, this has been rebased and is ready for its own review. There are two spurious commits with changes to Formula.ts, a637a7f and 46d1ac9. These are an artifact of how I originally submitted this on top of #498. But the latter one precisely undoes the other, and so they will "squash commit" to nothing: the only commit that matters at this point is a53d7ea, and as you can see at the top, GitHub realizes that only Scope.vue has changed. Sorry about the confusion, I should have just done this as an independent PR like I did with the last two, but I didn't set Git up quite right this time. But now all should be well for this to be reviewed normally and once it is ready, squash-merged like normal.