### PR TITLE
feat: Limit WebGL contexts in use by replacing thumbnails with snapshots when done

### DIFF
--- a/e2e/tests/scope.spec.ts
+++ b/e2e/tests/scope.spec.ts
@@ -83,6 +83,9 @@ test.describe('Scope: on some featured visualization', () => {
     })
 
     test('minimizing a tab', async ({page}) => {
+        await expect(page.locator('#visualiserTab')).not.toHaveClass(
+            /minimized/
+        )
         await page.locator('#visualiserTab .minimize').click()
         await expect(page.locator('#visualiserTab')).toHaveClass(/minimized/)
         await expect(

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -14,19 +14,32 @@
     let savedContainer: HTMLDivElement | null = null
     let specimen: Specimen | undefined = undefined
     let usingGC = false
+    const thumbnailGCmax = 8
     const props = defineProps<{query: string}>()
 
     onMounted(async () => {
         specimen = await Specimen.fromQuery(props.query)
         if (!(canvasContainer.value instanceof HTMLElement)) return
         savedContainer = canvasContainer.value
+        let setupNow = true
         if (specimen.visualizer.usesGL()) {
-            thumbnailGCcount.value += 1
-            usingGC = true
+            if (thumbnailGCcount.value < thumbnailGCmax) {
+                thumbnailGCcount.value += 1
+                usingGC = true
+            } else {
+                setupNow = false
+            }
         }
         console.log('THUMB setup', thumbnailGCcount.value, savedContainer)
-        specimen.setup(savedContainer)
-        setTimeout(() => specimen?.visualizer.stop(), 4000)
+        if (setupNow) {
+            specimen.setup(savedContainer)
+            setTimeout(() => specimen?.visualizer.stop(), 4000)
+        } else {
+            const limitMsg = document.createTextNode(
+                'All WebGL graphics contexts in use'
+            )
+            savedContainer.appendChild(limitMsg)
+        }
     })
 
     onUnmounted(() => {

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -4,23 +4,37 @@
 
 <script setup lang="ts">
     import {onMounted, onUnmounted, ref} from 'vue'
+
+    import {thumbnailGCcount} from './thumbnails'
+
     import {Specimen} from '@/shared/Specimen'
     import {DrawingUnmounted} from '@/visualizers/VisualizerInterface'
 
     const canvasContainer = ref<HTMLDivElement | null>(null)
     let savedContainer: HTMLDivElement | null = null
     let specimen: Specimen | undefined = undefined
+    let usingGC = false
     const props = defineProps<{query: string}>()
 
     onMounted(async () => {
         specimen = await Specimen.fromQuery(props.query)
         if (!(canvasContainer.value instanceof HTMLElement)) return
         savedContainer = canvasContainer.value
+        if (specimen.visualizer.usesGL()) {
+            thumbnailGCcount.value += 1
+            usingGC = true
+        }
+        console.log('THUMB setup', thumbnailGCcount.value, savedContainer)
         specimen.setup(savedContainer)
         setTimeout(() => specimen?.visualizer.stop(), 4000)
     })
 
     onUnmounted(() => {
+        if (usingGC) {
+            thumbnailGCcount.value -= 1
+            usingGC = false
+            console.log('THUMB cleanup', thumbnailGCcount.value, specimen)
+        }
         // Turns out canvasContainer has already been de-refed
         // by the time we get here, so we can't depart using that.
         // Hence the need for savedContainer, unfortunately.

--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -33,7 +33,28 @@
         console.log('THUMB setup', thumbnailGCcount.value, savedContainer)
         if (setupNow) {
             specimen.setup(savedContainer)
-            setTimeout(() => specimen?.visualizer.stop(), 4000)
+            setTimeout(() => {
+                if (usingGC) {
+                    thumbnailGCcount.value -= 1
+                    usingGC = false
+                    console.log(
+                        'THUMB early',
+                        thumbnailGCcount.value,
+                        specimen
+                    )
+                }
+                if (!specimen || !savedContainer) return
+                const canvas = savedContainer.querySelector('canvas')
+                if (canvas instanceof HTMLCanvasElement) {
+                    const {width, height} = canvas.getBoundingClientRect()
+                    const vizShot = new Image(width, height)
+                    vizShot.src = canvas.toDataURL()
+                    specimen.visualizer.depart(savedContainer)
+                    savedContainer.appendChild(vizShot)
+                } else {
+                    specimen.visualizer.stop()
+                }
+            }, 4000)
         } else {
             const limitMsg = document.createTextNode(
                 'All WebGL graphics contexts in use'

--- a/src/components/thumbnails.ts
+++ b/src/components/thumbnails.ts
@@ -1,0 +1,3 @@
+import {ref} from 'vue'
+
+export const thumbnailGCcount = ref(0)

--- a/src/visualizers/P5GLVisualizer.ts
+++ b/src/visualizers/P5GLVisualizer.ts
@@ -28,6 +28,10 @@ export function P5GLVisualizer<PD extends GenericParamDescription>(desc: PD) {
             this.name = this.category
         }
 
+        usesGL() {
+            return true
+        }
+
         // Just like P5Visualizer, but use WebGL renderer, load the brush,
         // and create a camera.
         // However we override rather than extend so there is only one call

--- a/src/visualizers/P5Visualizer.ts
+++ b/src/visualizers/P5Visualizer.ts
@@ -92,6 +92,9 @@ export function P5Visualizer<PD extends GenericParamDescription>(desc: PD) {
         drawingState: DrawingState = DrawingUnmounted
 
         within?: HTMLElement
+        usesGL() {
+            return false
+        }
         get sketch(): p5 {
             if (this._sketch === undefined) {
                 throw (

--- a/src/visualizers/VisualizerInterface.ts
+++ b/src/visualizers/VisualizerInterface.ts
@@ -87,6 +87,15 @@ implementations for all or almost all of them.
 
 export interface VisualizerInterface extends ParamableInterface {
     /** md */
+    usesGL(): boolean
+    /* **/
+    /** md
+:   Should return true if this visualizer requires a WebGL graphics context
+    (of which a limited number are available concurrently in a browser),
+    false otherwise.
+<!-- -->
+    **/
+    /** md */
     view(sequence: SequenceInterface): Promise<void>
     /* **/
     /** md


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

Resolves #506.

Also adds a method to the VisualizerInterface that indicates whether the visualizer uses WebGL. This could/should probably be used in testing to determine which tests use WebGL rather than checking the name of the visualizer, but that would be a different PR.

Also makes a baby step toward trying to understand the sporadic failures of the "minimizing a tab" e2e test in scope.test.ts.