### PR TITLE
fix: linebreak long numbers (in sequence mod)

### DIFF
--- a/src/sequences/OEIS.ts
+++ b/src/sequences/OEIS.ts
@@ -5,10 +5,12 @@ import type {Factorization} from './SequenceInterface'
 import simpleFactor from './simpleFactor'
 
 import {alertMessage} from '@/shared/alertMessage'
+import {breakableString} from '@/shared/layoutUtilities'
 import {math} from '@/shared/math'
 import type {ExtendedBigint} from '@/shared/math'
 import type {GenericParamDescription} from '@/shared/Paramable'
 import {ParamType} from '@/shared/ParamType'
+import {ValidationStatus} from '@/shared/ValidationStatus'
 
 /** md
 # OEIS sequence
@@ -61,6 +63,9 @@ const paramDesc = {
         required: false,
         description:
             'If nonzero, take the residue of each element to this modulus.',
+        validate: function (n: bigint, status: ValidationStatus) {
+            status.forbid(n < 0n, "can't be negative")
+        },
     },
 } satisfies GenericParamDescription
 
@@ -113,7 +118,7 @@ export class OEIS extends Cached(paramDesc) {
     get description() {
         // Unusual: override the per-instance description
         let desc = this.oeisName
-        if (this.modulus > 0n) desc += ` (mod ${this.modulus})`
+        if (this.modulus) desc += ` (mod ${breakableString(this.modulus)})`
         return desc
     }
 

--- a/src/shared/__tests__/layoutUtilities.spec.ts
+++ b/src/shared/__tests__/layoutUtilities.spec.ts
@@ -1,0 +1,20 @@
+import {describe, it, expect} from 'vitest'
+
+import {breakableString} from '../layoutUtilities'
+// isMobile not easily unit testable, since it needs a browser context
+
+describe('breakableString', () => {
+    it('leaves small numbers alone', () => {
+        expect(breakableString(2n)).toBe(2n.toString())
+        expect(breakableString(123456789n)).toBe(123456789n.toString())
+        expect(breakableString(-123456789n)).toBe((-123456789n).toString())
+    })
+    it('splits larger numbers into groups of 3 digits from the right', () => {
+        expect(breakableString(1234567890n)).toBe('1 234 567 890')
+        expect(breakableString(12345678901n)).toBe('12 345 678 901')
+        expect(breakableString(123456789012n)).toBe('123 456 789 012')
+        expect(breakableString(-1234567890n)).toBe('-1 234 567 890')
+        expect(breakableString(-12345678901n)).toBe('-12 345 678 901')
+        expect(breakableString(-123456789012n)).toBe('-123 456 789 012')
+    })
+})

--- a/src/shared/layoutUtilities.ts
+++ b/src/shared/layoutUtilities.ts
@@ -7,3 +7,22 @@ export function isMobile() {
     )
     return window.innerWidth < tabletBreakpoint
 }
+
+// Returns the decimal string of a big number with (breaking) thin spaces
+// every three characters if it is over nine digits long
+export function breakableString(n: bigint) {
+    let s = n.toString()
+    const minus = Number(n < 0) // stupid typescript, Number conversion auto
+    const breaklength = 10 + minus
+    if (s.length < breaklength) return s
+    let firstblock = s.length % 3
+    if (!firstblock && minus) firstblock = 4
+    let prefix = ''
+    if (firstblock) {
+        prefix = s.substr(0, firstblock)
+        s = s.substr(firstblock)
+    }
+    const parts = Array.from(s.match(/.{3}/g) ?? [])
+    if (prefix) parts.unshift(prefix)
+    return parts.join('\u2009') // thin space
+}

--- a/src/shared/layoutUtilities.ts
+++ b/src/shared/layoutUtilities.ts
@@ -16,12 +16,13 @@ export function breakableString(n: bigint) {
     const breaklength = 10 + minus
     if (s.length < breaklength) return s
     let firstblock = s.length % 3
-    if (!firstblock && minus) firstblock = 4
+    if (firstblock === 1 && minus) firstblock = 4
     let prefix = ''
     if (firstblock) {
         prefix = s.substr(0, firstblock)
         s = s.substr(firstblock)
     }
+    console.log(n, firstblock, prefix, s)
     const parts = Array.from(s.match(/.{3}/g) ?? [])
     if (prefix) parts.unshift(prefix)
     return parts.join('\u2009') // thin space


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR provides a utility for converting large bigints to strings that include thin spaces every three characters so that they can linebreak in paragraphs, etc (and they are more readable that way anyway). Currently, such numbers were only creating a problem in the OEIS sequence modulus, so that's the only place the facility is used; we could apply it more generally in the future if more such problems crop up.

Resolves #512.
