### PR TITLE
chore: Remaining Turtle visualizer items for alpha

### DIFF
--- a/src/shared/defineFeatured.ts
+++ b/src/shared/defineFeatured.ts
@@ -167,7 +167,7 @@ const featuredSIMs = [
         'Turtle',
         'OEIS A000045',
         'domain=0+1&angles=8+120&steps=40+400'
-            + '&animationControls=true&folds=200+0&showMode=0'
+            + '&animationControls=true&folds=200+0&drawPath=1'
             + '&bgColor=4f4875&strokeColor=%23cec0c0',
         'modulus=9&last=999&length=1000'
     ),


### PR DESCRIPTION
By submitting this PR, I am indicating to the Numberscope maintainers that I have read and understood the [contributing guidelines](https://numberscope.colorado.edu/doc/CONTRIBUTING/) and that this PR follows those guidelines to the best of my knowledge. I have also read the [pull request checklist](https://numberscope.colorado.edu/doc/doc/pull-request-checklist/) and followed the instructions therein.

<hr/>

This PR accomplishes two things:

 * Avoids oscillating warnings about sequence values being out of domain by using cumulative rather than incremental statistics.
 * Allows path length growth simultaneously with path shape morphing, reconfiguring parameter tab as discussed.

Resolves #520.
Resolves #557.