### PR TITLE
fix alignment of navbar links

### DIFF
--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -253,6 +253,7 @@
             }
 
             #navbar-links {
+                align-items: center;
                 display: flex;
                 flex-direction: row;
                 margin-top: 0;


### PR DESCRIPTION
Before:

<img width="217" height="74" alt="image" src="https://github.com/user-attachments/assets/2ae8497e-327d-4c75-a6fe-9ffb54a3252a" />

After:

<img width="215" height="72" alt="image" src="https://github.com/user-attachments/assets/94e3f70a-c585-44fd-8565-447c3f98131d" />
