### PR TITLE
fix help menu gap

### DIFF
--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -161,7 +161,7 @@
                 padding-left: 0.5em;
 
                 padding-bottom: var(--popup-offset);
-                margin-bottom: calc(-1 * var(--popup-offset));
+                margin-bottom: calc(-1.05 * var(--popup-offset));
 
                 a {
                     font-family: var(--ns-font-display);

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -150,6 +150,19 @@
                 position: relative;
                 padding-right: 0.5em;
 
+                /** vertical offset between #help-popup and the text */
+                --popup-offset: 0.3ex;
+
+                /*
+                 * increase the hoverable area so that the popup doesn't vanish
+                 * when moving the mouse from the popup trigger to the popup
+                 */
+                margin-left: -0.5em;
+                padding-left: 0.5em;
+
+                padding-bottom: var(--popup-offset);
+                margin-bottom: calc(-1 * var(--popup-offset));
+
                 a {
                     font-family: var(--ns-font-display);
                     text-decoration: none;
@@ -171,7 +184,7 @@
                     z-index: 10000;
                     background-color: var(--ns-color-white);
                     opacity: 1;
-                    margin-top: 0.3ex;
+                    margin-top: var(--popup-offset);
                     padding-bottom: 0.5ex;
                     padding-top: 0.5ex;
                     border: 1px solid var(--ns-color-black);


### PR DESCRIPTION
Fix the help menu gap introduced in #606 (see https://github.com/numberscope/frontscope/pull/620#issuecomment-3837436008)

Here I have highlighted the hover surface in red: the gap causes the help popup to vanish:

<img width="217" height="180" alt="hover surface small" src="https://github.com/user-attachments/assets/e12062c8-586a-4a2f-b58e-d3f808f72740" />

I expanded the hover surface to fix this (using negative margins to prevent any other layout shift); I also expanded the horizontal hover surface so that you don't fall off when moving diagonally (left+down) to the popup:

<img width="207" height="177" alt="hover surface big" src="https://github.com/user-attachments/assets/cc228853-c202-44ea-b447-982a13dd159d" />
