### PR TITLE
Preliminary mobile styling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,9 +49,9 @@ jobs:
             - name: End-to-end test
               run: npx playwright test -c e2e/playci.config.ts
 ### Uncomment when you need to re-extract snapshots
-#            - name: Extract snapshots
-#              if: always()
-#              uses: actions/upload-artifact@v4
-#              with:
-#                  name: ci_actual_snapshots
-#                  path: e2e/results/manual/output
+            - name: Extract snapshots
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ci_actual_snapshots
+                  path: e2e/results/manual/output

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.4.0",
             "hasInstallScript": true,
             "dependencies": {
+                "@phosphor-icons/vue": "^2.2.1",
                 "axios": "^1.12.0",
                 "bigint-isqrt": "^0.3.2",
                 "bigint-mod-arith": "^3.3.1",
@@ -845,6 +846,18 @@
             "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
             "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
             "dev": true
+        },
+        "node_modules/@phosphor-icons/vue": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@phosphor-icons/vue/-/vue-2.2.1.tgz",
+            "integrity": "sha512-3RNg1utc2Z5RwPKWFkW3eXI/0BfQAwXgtFxPUPeSzi55jGYUq16b+UqcgbKLazWFlwg5R92OCLKjDiJjeiJcnA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "vue": ">=3.2.39"
+            }
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -6442,6 +6455,12 @@
             "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
             "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
             "dev": true
+        },
+        "@phosphor-icons/vue": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@phosphor-icons/vue/-/vue-2.2.1.tgz",
+            "integrity": "sha512-3RNg1utc2Z5RwPKWFkW3eXI/0BfQAwXgtFxPUPeSzi55jGYUq16b+UqcgbKLazWFlwg5R92OCLKjDiJjeiJcnA==",
+            "requires": {}
         },
         "@pkgjs/parseargs": {
             "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "postinstall": "git config --local include.path ../.gitconfig && python3 -m venv .venv && cd tools && node pyrun.mjs python -m pip install -U pip && node pyrun.mjs pip install -r requirements.txt"
     },
     "dependencies": {
+        "@phosphor-icons/vue": "^2.2.1",
         "axios": "^1.12.0",
         "bigint-isqrt": "^0.3.2",
         "bigint-mod-arith": "^3.3.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@
 </script>
 
 <!-- Global styles. This style tag is explicitly unscoped. -->
-<style>
+<style lang="scss">
     #container {
         display: flex;
         flex-direction: column;
@@ -108,8 +108,8 @@
         // Large devices (desktops)
         @media (min-width: $desktop-breakpoint) { ... }
         */
-        --ns-breakpoint-mobile: $mobile-breakpoint;
-        --ns-breakpoint-tablet: $tablet-breakpoint;
+        --ns-breakpoint-mobile: #{$mobile-breakpoint};
+        --ns-breakpoint-tablet: #{$tablet-breakpoint};
         /* Not actually used at the moment:
           --ns-breakpoint-desktop: 1200px;
          */

--- a/src/App.vue
+++ b/src/App.vue
@@ -86,6 +86,8 @@
         --ns-font-weight-medium: 500;
 
         /* Dimensions */
+        /* TODO: compute this dynamically */
+        --ns-mobile-navbar-height: 45px;
         --ns-desktop-navbar-height: 76px;
         --ns-desktop-tab-width: 300px;
         --ns-specimen-card-width: 216px;

--- a/src/components/SpecimenBar.vue
+++ b/src/components/SpecimenBar.vue
@@ -4,7 +4,7 @@
             <label>
                 Specimen name
                 <input
-                    id="spec-name"
+                    class="spec-name"
                     type="text"
                     :value="specimen.name"
                     @keyup.enter="blurName()"
@@ -117,7 +117,11 @@
     }
 
     function blurName() {
-        window.document.getElementById('spec-name')?.blur()
+        for (const input of window.document.getElementsByClassName(
+            'spec-name'
+        )) {
+            input.blur()
+        }
     }
 
     function refresh() {

--- a/src/components/SpecimenBar.vue
+++ b/src/components/SpecimenBar.vue
@@ -117,9 +117,9 @@
     }
 
     function blurName() {
-        for (const input of window.document.getElementsByClassName(
-            'spec-name'
-        )) {
+        for (const input of Array.from(
+            document.getElementsByClassName('spec-name')
+        ) as HTMLInputElement[]) {
             input.blur()
         }
     }

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -309,8 +309,7 @@
         display: none;
     }
     .tab {
-        width: 300px;
-        height: fit-content;
+        width: 100%;
     }
     .content {
         padding: 0px 16px 16px 16px;

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -60,7 +60,7 @@ visualizers you can select.
                     }
                 ">
                 <PhDna
-                    alt="Toggle specimen bar"
+                    alt="Toggle sequence tab"
                     :size="24"
                     color="currentColor" />
             </button>
@@ -76,7 +76,7 @@ visualizers you can select.
                     }
                 ">
                 <PhMicroscope
-                    alt="Toggle visualizer bar"
+                    alt="Toggle visualizer tab"
                     :size="24"
                     color="currentColor" />
             </button>
@@ -331,6 +331,7 @@ visualizers you can select.
      * Used when the window is resized.
      */
     export function positionAndSizeAllTabs(): void {
+    if (isMobile()) return;
         // First reset the "empty" classes and recompute them, just in case:
         document
             .querySelectorAll('.dropzone')
@@ -491,9 +492,7 @@ visualizers you can select.
     })
 
     onMounted(() => {
-        if (!isMobile) {
             positionAndSizeAllTabs()
-        }
         canvasContainer = document.getElementById('canvas-container')!
 
         if (!initialLoad) throw new Error("showURL didn't promise Specimen")
@@ -685,6 +684,7 @@ visualizers you can select.
         display: none;
     }
     #main {
+      flex: 1;
         display: flex;
         height: 100%;
     }
@@ -854,6 +854,7 @@ visualizers you can select.
             width: 300px;
             order: unset;
             height: fit-content;
+            position: absolute;
 
             padding-left: auto;
             padding-right: auto;

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -47,6 +47,40 @@ visualizers you can select.
             id="specimen-bar-desktop"
             :specimen
             @update-specimen-name="handleSpecimenUpdate" />
+        <div id="phone-opener-container">
+            <button
+                aria-controls="sequenceTab"
+                :aria-expanded="Boolean(sequenceTabOpen)"
+                class="phone-opener"
+                type="button"
+                @click="
+                    () => {
+                        sequenceTabOpen = !sequenceTabOpen
+                        visualizerTabOpen = false
+                    }
+                ">
+                <PhDna
+                    alt="Toggle specimen bar"
+                    :size="24"
+                    color="currentColor" />
+            </button>
+            <button
+                aria-controls="visualizerTab"
+                :aria-expanded="Boolean(visualizerTabOpen)"
+                class="phone-opener"
+                type="button"
+                @click="
+                    () => {
+                        visualizerTabOpen = !visualizerTabOpen
+                        sequenceTabOpen = false
+                    }
+                ">
+                <PhMicroscope
+                    alt="Toggle visualizer bar"
+                    :size="24"
+                    color="currentColor" />
+            </button>
+        </div>
     </NavBar>
     <div id="specimen-container">
         <SwitcherModal
@@ -70,10 +104,11 @@ visualizers you can select.
                     changeVisualizerOpen = false
                 }
             " />
-        <tab
+        <Tab
             id="sequenceTab"
             class="tab docked"
             docked="top-right"
+            :class="{visible: sequenceTabOpen}"
             :last-coords-x="Math.floor(tabWidth / 3)"
             :last-coords-y="Math.floor(tabWidth / 3)">
             <ParamEditor
@@ -87,10 +122,11 @@ visualizers you can select.
                         updateURL()
                     }
                 " />
-        </tab>
-        <tab
-            id="visualiserTab"
+        </Tab>
+        <Tab
+            id="visualizerTab"
             class="tab docked"
+            :class="{visible: visualizerTabOpen}"
             docked="bottom-right"
             last-dropzone="bottom-right"
             :last-coords-x="Math.floor((2 * tabWidth) / 3)"
@@ -105,7 +141,7 @@ visualizers you can select.
                         updateURL()
                     }
                 " />
-        </tab>
+        </Tab>
         <SpecimenBar
             id="specimen-bar-phone"
             class="specimen-bar"
@@ -162,6 +198,7 @@ visualizers you can select.
 </template>
 
 <script lang="ts">
+    import {PhDna, PhMicroscope} from '@phosphor-icons/vue'
     import NavBar from './minor/NavBar.vue'
     import SpecimenBar from '../components/SpecimenBar.vue'
     import {clearErrorOverlay} from '@/shared/alertMessage'
@@ -372,6 +409,9 @@ visualizers you can select.
     const changeSequenceOpen = ref(false)
     const changeVisualizerOpen = ref(false)
 
+    const sequenceTabOpen = ref(false)
+    const visualizerTabOpen = ref(false)
+
     const router = useRouter()
     const route = useRoute()
 
@@ -451,7 +491,9 @@ visualizers you can select.
     })
 
     onMounted(() => {
-        positionAndSizeAllTabs()
+        if (!isMobile) {
+            positionAndSizeAllTabs()
+        }
         canvasContainer = document.getElementById('canvas-container')!
 
         if (!initialLoad) throw new Error("showURL didn't promise Specimen")
@@ -619,6 +661,23 @@ visualizers you can select.
 
 <style scoped lang="scss">
     // mobile styles
+    #phone-opener-container {
+        align-items: center;
+        display: flex;
+        gap: 0.5em;
+        margin-right: 0.5em;
+    }
+
+    .phone-opener {
+        /* remove button styles */
+        background: none;
+        border-style: none;
+
+        /* center contents */
+        display: inline-flex;
+        align-items: center;
+    }
+
     .navbar {
         display: unset;
     }
@@ -636,6 +695,10 @@ visualizers you can select.
         min-height: fit-content;
         padding-left: auto;
         padding-right: auto;
+
+        @media (max-width: $mobile-breakpoint) {
+            flex: 1;
+        }
     }
     #canvas-container {
         flex: 1;
@@ -647,7 +710,6 @@ visualizers you can select.
         order: 1;
         z-index: -1;
         border-bottom: 1px solid var(--ns-color-black);
-        height: 300px;
         width: 100%;
     }
     .dropzone-container {
@@ -662,27 +724,44 @@ visualizers you can select.
         display: none;
     }
     #sequenceTab {
-        width: 100%;
-        padding-left: auto;
-        padding-right: auto;
         order: 3;
-        border-bottom: 1px solid var(--ns-color-black);
-        height: fit-content;
     }
-    #visualiserTab {
+    #visualizerTab {
         width: 100%;
         padding-left: auto;
         padding-right: auto;
         order: 4;
         border-bottom: 1px solid var(--ns-color-black);
-        height: fit-content;
     }
     #specimen-bar-phone {
         order: 2;
         padding-left: auto;
         padding-right: auto;
         border-bottom: 1px solid var(--ns-color-black);
+
+        display: none;
+
+        &.visible {
+            display: block;
+        }
     }
+
+    @media (max-width: $mobile-breakpoint) {
+        .tab {
+            background: var(--ns-color-white);
+            bottom: 0;
+            height: 0;
+            overflow: hidden;
+            position: absolute;
+            transition: height 150ms ease-in-out;
+
+            &.visible {
+                height: calc(0.5 * (100vh - var(--ns-mobile-navbar-height)));
+                overflow: auto;
+            }
+        }
+    }
+
     // tablet & desktop styles
     @media (min-width: $tablet-breakpoint) {
         #specimen-bar-desktop {
@@ -696,7 +775,8 @@ visualizers you can select.
             border: 0px;
         }
         #sequenceTab,
-        #visualiserTab {
+        #visualizerTab {
+            display: block;
             width: var(--ns-desktop-tab-width);
         }
         #specimen-container {
@@ -708,7 +788,6 @@ visualizers you can select.
         }
 
         #canvas-container {
-            height: unset;
             order: unset;
             flex: 1;
             position: relative;
@@ -773,8 +852,16 @@ visualizers you can select.
 
         .tab {
             width: 300px;
-            position: absolute;
             order: unset;
+            height: fit-content;
+
+            padding-left: auto;
+            padding-right: auto;
+            border-bottom: 1px solid var(--ns-color-black);
+        }
+
+        #phone-opener-container {
+            display: none;
         }
     }
 </style>

--- a/src/views/Scope.vue
+++ b/src/views/Scope.vue
@@ -331,7 +331,7 @@ visualizers you can select.
      * Used when the window is resized.
      */
     export function positionAndSizeAllTabs(): void {
-    if (isMobile()) return;
+        if (isMobile()) return
         // First reset the "empty" classes and recompute them, just in case:
         document
             .querySelectorAll('.dropzone')
@@ -492,7 +492,7 @@ visualizers you can select.
     })
 
     onMounted(() => {
-            positionAndSizeAllTabs()
+        positionAndSizeAllTabs()
         canvasContainer = document.getElementById('canvas-container')!
 
         if (!initialLoad) throw new Error("showURL didn't promise Specimen")
@@ -684,7 +684,7 @@ visualizers you can select.
         display: none;
     }
     #main {
-      flex: 1;
+        flex: 1;
         display: flex;
         height: 100%;
     }
@@ -735,14 +735,17 @@ visualizers you can select.
     }
     #specimen-bar-phone {
         order: 2;
-        padding-left: auto;
-        padding-right: auto;
+        padding: 8px;
         border-bottom: 1px solid var(--ns-color-black);
+        position: fixed;
+        bottom: 0;
+        z-index: 1;
+        left: 0;
+        background: var(--ns-color-white);
 
-        display: none;
-
-        &.visible {
-            display: block;
+        /* align with label */
+        :deep(.spec-name) {
+            padding-left: 0;
         }
     }
 
@@ -754,6 +757,7 @@ visualizers you can select.
             overflow: hidden;
             position: absolute;
             transition: height 150ms ease-in-out;
+            z-index: 2;
 
             &.visible {
                 height: calc(0.5 * (100vh - var(--ns-mobile-navbar-height)));

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -1,291 +1,295 @@
 <template>
-  <header>
-    <nav>
-      <div id="navbar-main">
-        <a href="/doc/doc/about/">
-          <img :src="LogoWithMicroscope" alt="A microscope icon." />
-        </a>
-        <button
-          id="navbar-toggler"
-          type="button"
-          aria-controls="navbarSupportedContent"
-          :aria-expanded="menuOpen"
-          aria-label="Toggle navigation."
-          @click="toggleMenu"
-        >
-          <span class="material-icons-sharp">menu</span>
-        </button>
-      </div>
-      <slot class="specimen-bar" />
-      <div class="burger-menu">
-        <div id="navbar-links" :class="{ open: menuOpen }">
-          <RouterLink class="nav-link" to="/gallery" @click="closeMenu">
-            Gallery
-          </RouterLink>
-          <div class="help-popper">
-            <a href="/doc/">Help</a>
-            <div id="help-popup" class="shadowed">
-              <div class="nav-link">
-                <a href="/doc/doc/user_guide/">User Guide</a>
-              </div>
-              <div class="leftdented">
-                <a class="nav-link" :href="vizLink()">
-                  {{ specimen.visualizerName() }}
-                  Visualizer </a
-                >┤
-              </div>
-              <div class="leftdented tweakup">
-                <a class="nav-link" :href="seqLink()">
-                  {{ seqWord() }} Sequence </a
-                >┘
-              </div>
-              <div class="nav-link">
-                <a href="/doc/">Full Documentation</a>
-              </div>
+    <header>
+        <nav>
+            <div id="navbar-main">
+                <a id="logo" href="/doc/doc/about/">
+                    <img :src="LogoWithMicroscope" alt="A microscope icon.">
+                </a>
+                <button
+                    id="navbar-toggler"
+                    type="button"
+                    aria-controls="navbarSupportedContent"
+                    :aria-expanded="menuOpen"
+                    aria-label="Toggle navigation."
+                    @click="toggleMenu">
+                    <span class="material-icons-sharp">menu</span>
+                </button>
             </div>
-          </div>
-        </div>
-        <div class="close material-icons-sharp">close</div>
-      </div>
-    </nav>
-  </header>
+            <slot class="specimen-bar" />
+            <div class="burger-menu">
+                <div id="navbar-links" :class="{open: menuOpen}">
+                    <RouterLink
+                        class="nav-link"
+                        to="/gallery"
+                        @click="closeMenu">
+                        Gallery
+                    </RouterLink>
+                    <div class="help-popper">
+                        <a href="/doc/">Help</a>
+                        <div id="help-popup" class="shadowed">
+                            <div class="nav-link">
+                                <a href="/doc/doc/user_guide/">User Guide</a>
+                            </div>
+                            <div class="leftdented">
+                                <a class="nav-link" :href="vizLink()">
+                                    {{ specimen.visualizerName() }}
+                                    Visualizer </a>┤
+                            </div>
+                            <div class="leftdented tweakup">
+                                <a class="nav-link" :href="seqLink()">
+                                    {{ seqWord() }} Sequence </a>┘
+                            </div>
+                            <div class="nav-link">
+                                <a href="/doc/">Full Documentation</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="close material-icons-sharp">close</div>
+            </div>
+        </nav>
+    </header>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-import type { PropType, UnwrapNestedRefs } from "vue";
-import { RouterLink } from "vue-router";
+    import {ref} from 'vue'
+    import type {PropType, UnwrapNestedRefs} from 'vue'
+    import {RouterLink} from 'vue-router'
 
-import LogoWithMicroscope from "@/assets/img/logo.svg";
-import type { Specimen } from "@/shared/Specimen";
+    import LogoWithMicroscope from '@/assets/img/logo.svg'
+    import type {Specimen} from '@/shared/Specimen'
 
-const props = defineProps({
-  specimen: {
-    type: Object as PropType<UnwrapNestedRefs<Specimen>>,
-    required: true,
-  },
-});
+    const props = defineProps({
+        specimen: {
+            type: Object as PropType<UnwrapNestedRefs<Specimen>>,
+            required: true,
+        },
+    })
 
-const menuOpen = ref(false);
+    const menuOpen = ref(false)
 
-function toggleMenu() {
-  menuOpen.value = !menuOpen.value;
-}
+    function toggleMenu() {
+        menuOpen.value = !menuOpen.value
+    }
 
-function closeMenu() {
-  menuOpen.value = false;
-}
+    function closeMenu() {
+        menuOpen.value = false
+    }
 
-function seqWord() {
-  return props.specimen.sequenceName().split(/[\s:]/, 2)[0] || "";
-}
-function seqLink() {
-  return `/doc/src/sequences/${seqWord()}/`;
-}
-function vizLink() {
-  return `/doc/src/visualizers/${props.specimen.visualizerKey}/`;
-}
+    function seqWord() {
+        return props.specimen.sequenceName().split(/[\s:]/, 2)[0] || ''
+    }
+    function seqLink() {
+        return `/doc/src/sequences/${seqWord()}/`
+    }
+    function vizLink() {
+        return `/doc/src/visualizers/${props.specimen.visualizerKey}/`
+    }
 </script>
 
 <style scoped lang="scss">
-nav {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 8px 16px 8px 16px;
-  border-bottom: 1px solid var(--ns-color-black);
-  position: relative;
+    nav {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding: 8px 16px 8px 16px;
+        border-bottom: 1px solid var(--ns-color-black);
+        position: relative;
 
-  #navbar-main {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+        #navbar-main {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
 
-    #navbar-toggler {
-      background: none;
-      border: none;
-      display: flex;
-      justify-content: center;
-      align-items: center;
+            #navbar-toggler {
+                background: none;
+                border: none;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+        }
+
+        .close {
+            display: none;
+            font-size: 32px;
+            cursor: pointer;
+        }
+
+        .burger-menu {
+            background-color: var(--ns-color-white);
+            color: var(--ns-color-black);
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+
+            &.open {
+                .material-icons-sharp {
+                    display: block;
+                }
+            }
+        }
+
+        #navbar-links {
+            width: 100%;
+            display: none;
+            flex-direction: column;
+            color: var(--ns-color-black);
+            &.open {
+                display: flex;
+                z-index: 1000;
+            }
+
+            @media (max-width: $mobile-breakpoint) {
+                /* should not push content down */
+                background-color: var(--ns-color-white);
+                position: absolute;
+                top: 100%;
+                left: 0;
+                width: 100%;
+                padding: 0.2em 0.5em;
+            }
+
+            @media (min-width: $mobile-breakpoint) {
+                display: flex;
+            }
+
+            @media (min-width: $tablet-breakpoint) {
+                margin-top: 8px;
+            }
+
+            .help-popper {
+                cursor: pointer;
+                font-family: var(--ns-font-display);
+                font-size: var(--ns-size-display);
+                position: relative;
+                padding-right: 0.5em;
+
+                a {
+                    font-family: var(--ns-font-display);
+                    text-decoration: none;
+                }
+                a:hover {
+                    text-decoration: underline;
+                }
+
+                #help-popup {
+                    visibility: hidden;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-end;
+                    align-content: flex-end;
+                    white-space: nowrap;
+                    position: absolute;
+                    right: 0;
+                    width: auto;
+                    z-index: 10000;
+                    background-color: var(--ns-color-white);
+                    opacity: 1;
+                    margin-top: 0.3ex;
+                    padding-bottom: 0.5ex;
+                    padding-top: 0.5ex;
+                    border: 1px solid var(--ns-color-black);
+
+                    .leftdented {
+                        padding-right: 0.5em;
+                    }
+
+                    .tweakup {
+                        position: relative;
+                        bottom: 6px;
+                    }
+
+                    .nav-link {
+                        color: var(--ns-color-black);
+                        padding-top: 0ex;
+                        padding-bottom: 0ex;
+                    }
+
+                    a {
+                        font-family: var(--ns-font-main);
+                        font-size: var(--ns-size-heading);
+                        text-decoration: none;
+                        padding-right: 0px;
+                    }
+
+                    a:hover {
+                        text-decoration: underline;
+                    }
+                }
+
+                &:hover #help-popup {
+                    visibility: visible;
+                    opacity: 1;
+                }
+            }
+
+            .nav-link {
+                font-family: var(--ns-font-display);
+                font-size: var(--ns-size-display);
+                color: var(--ns-color-black);
+                padding-right: 0.5em;
+                padding-bottom: 0.2ex;
+                text-decoration: none;
+
+                @media (min-width: $tablet-breakpoint) {
+                    margin-top: 8px;
+                    padding-top: 0.2ex;
+                    padding-left: 0.5em;
+                }
+
+                &:focus,
+                &:hover {
+                    text-decoration: underline;
+                }
+
+                a:hover {
+                    text-decoration: underline;
+                }
+            }
+        }
     }
-  }
+    #logo {
+        img {
+            height: 24px;
 
-  .close {
-    display: none;
-    font-size: 32px;
-    cursor: pointer;
-  }
-
-  .burger-menu {
-    background-color: var(--ns-color-white);
-    color: var(--ns-color-black);
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-
-    &.open {
-      .material-icons-sharp {
-        display: block;
-      }
+            @media (min-width: $tablet-breakpoint) {
+                height: 32px;
+            }
+        }
     }
-  }
-
-  #navbar-links {
-    width: 100%;
-    display: none;
-    flex-direction: column;
-    color: var(--ns-color-black);
-    &.open {
-      display: flex;
-      z-index: 1000;
-    }
-
-    @media (max-width: $mobile-breakpoint) {
-      /* should not push content down */
-      background-color: var(--ns-color-white);
-      position: absolute;
-      top: 100%;
-      left: 0;
-      width: 100%;
-      padding: 0.2em 0.5em;
-    }
-
-    @media (min-width: $mobile-breakpoint) {
-      display: flex;
+    .specimen-bar {
+        display: none;
     }
 
     @media (min-width: $tablet-breakpoint) {
-      margin-top: 8px;
-    }
+        nav {
+            justify-content: space-between;
+            align-items: center;
+            flex-direction: row;
+            height: var(--ns-desktop-navbar-height);
+            #navbar-main {
+                #navbar-toggler {
+                    display: none;
+                }
+            }
 
-    .help-popper {
-      cursor: pointer;
-      font-family: var(--ns-font-display);
-      font-size: var(--ns-size-display);
-      position: relative;
-      padding-right: 0.5em;
-
-      a {
-        font-family: var(--ns-font-display);
-        text-decoration: none;
-      }
-      a:hover {
-        text-decoration: underline;
-      }
-
-      #help-popup {
-        visibility: hidden;
-        display: flex;
-        flex-direction: column;
-        align-items: flex-end;
-        align-content: flex-end;
-        white-space: nowrap;
-        position: absolute;
-        right: 0;
-        width: auto;
-        z-index: 10000;
-        background-color: var(--ns-color-white);
-        opacity: 1;
-        margin-top: 0.3ex;
-        padding-bottom: 0.5ex;
-        padding-top: 0.5ex;
-        border: 1px solid var(--ns-color-black);
-
-        .leftdented {
-          padding-right: 0.5em;
+            #navbar-links {
+                align-items: center;
+                display: flex;
+                flex-direction: row;
+                margin-top: 0;
+                border-bottom: none;
+                width: unset;
+                gap: 24px;
+                .nav-link {
+                    margin-top: 0;
+                }
+            }
         }
-
-        .tweakup {
-          position: relative;
-          bottom: 6px;
+        .specimen-bar {
+            display: flex;
         }
-
-        .nav-link {
-          color: var(--ns-color-black);
-          padding-top: 0ex;
-          padding-bottom: 0ex;
-        }
-
-        a {
-          font-family: var(--ns-font-main);
-          font-size: var(--ns-size-heading);
-          text-decoration: none;
-          padding-right: 0px;
-        }
-
-        a:hover {
-          text-decoration: underline;
-        }
-      }
-
-      &:hover #help-popup {
-        visibility: visible;
-        opacity: 1;
-      }
     }
-
-    .nav-link {
-      font-family: var(--ns-font-display);
-      font-size: var(--ns-size-display);
-      color: var(--ns-color-black);
-      padding-right: 0.5em;
-      padding-bottom: 0.2ex;
-      text-decoration: none;
-
-      @media (min-width: $tablet-breakpoint) {
-        margin-top: 8px;
-        padding-top: 0.2ex;
-        padding-left: 0.5em;
-      }
-
-      &:focus,
-      &:hover {
-        text-decoration: underline;
-      }
-
-      a:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-}
-#logo {
-  img {
-    height: 32px;
-  }
-}
-.specimen-bar {
-  display: none;
-}
-
-@media (min-width: $tablet-breakpoint) {
-  nav {
-    justify-content: space-between;
-    align-items: center;
-    flex-direction: row;
-    height: var(--ns-desktop-navbar-height);
-    #navbar-main {
-      #navbar-toggler {
-        display: none;
-      }
-    }
-
-    #navbar-links {
-      align-items: center;
-      display: flex;
-      flex-direction: row;
-      margin-top: 0;
-      border-bottom: none;
-      width: unset;
-      gap: 24px;
-      .nav-link {
-        margin-top: 0;
-      }
-    }
-  }
-  .specimen-bar {
-    display: flex;
-  }
-}
 </style>

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -1,272 +1,291 @@
 <template>
-    <header>
-        <nav>
-            <div id="navbar-main">
-                <a href="/doc/doc/about/">
-                    <img :src="LogoWithMicroscope" alt="A microscope icon.">
-                </a>
-                <button
-                    id="navbar-toggler"
-                    type="button"
-                    aria-controls="navbarSupportedContent"
-                    :aria-expanded="menuOpen"
-                    aria-label="Toggle navigation."
-                    @click="toggleMenu">
-                    <span class="material-icons-sharp">menu</span>
-                </button>
+  <header>
+    <nav>
+      <div id="navbar-main">
+        <a href="/doc/doc/about/">
+          <img :src="LogoWithMicroscope" alt="A microscope icon." />
+        </a>
+        <button
+          id="navbar-toggler"
+          type="button"
+          aria-controls="navbarSupportedContent"
+          :aria-expanded="menuOpen"
+          aria-label="Toggle navigation."
+          @click="toggleMenu"
+        >
+          <span class="material-icons-sharp">menu</span>
+        </button>
+      </div>
+      <slot class="specimen-bar" />
+      <div class="burger-menu">
+        <div id="navbar-links" :class="{ open: menuOpen }">
+          <RouterLink class="nav-link" to="/gallery" @click="closeMenu">
+            Gallery
+          </RouterLink>
+          <div class="help-popper">
+            <a href="/doc/">Help</a>
+            <div id="help-popup" class="shadowed">
+              <div class="nav-link">
+                <a href="/doc/doc/user_guide/">User Guide</a>
+              </div>
+              <div class="leftdented">
+                <a class="nav-link" :href="vizLink()">
+                  {{ specimen.visualizerName() }}
+                  Visualizer </a
+                >┤
+              </div>
+              <div class="leftdented tweakup">
+                <a class="nav-link" :href="seqLink()">
+                  {{ seqWord() }} Sequence </a
+                >┘
+              </div>
+              <div class="nav-link">
+                <a href="/doc/">Full Documentation</a>
+              </div>
             </div>
-            <slot class="specimen-bar" />
-            <div class="burger-menu">
-                <div id="navbar-links" :class="{open: menuOpen}">
-                    <RouterLink
-                        class="nav-link"
-                        to="/gallery"
-                        @click="closeMenu">
-                        Gallery
-                    </RouterLink>
-                    <div class="help-popper">
-                        <a href="/doc/">Help</a>
-                        <div id="help-popup" class="shadowed">
-                            <div class="nav-link">
-                                <a href="/doc/doc/user_guide/">User Guide</a>
-                            </div>
-                            <div class="leftdented">
-                                <a class="nav-link" :href="vizLink()">
-                                    {{ specimen.visualizerName() }}
-                                    Visualizer </a>┤
-                            </div>
-                            <div class="leftdented tweakup">
-                                <a class="nav-link" :href="seqLink()">
-                                    {{ seqWord() }} Sequence </a>┘
-                            </div>
-                            <div class="nav-link">
-                                <a href="/doc/">Full Documentation</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="close material-icons-sharp">close</div>
-            </div>
-        </nav>
-    </header>
+          </div>
+        </div>
+        <div class="close material-icons-sharp">close</div>
+      </div>
+    </nav>
+  </header>
 </template>
 
 <script setup lang="ts">
-    import {ref} from 'vue'
-    import type {PropType, UnwrapNestedRefs} from 'vue'
-    import {RouterLink} from 'vue-router'
+import { ref } from "vue";
+import type { PropType, UnwrapNestedRefs } from "vue";
+import { RouterLink } from "vue-router";
 
-    import LogoWithMicroscope from '@/assets/img/logo.svg'
-    import type {Specimen} from '@/shared/Specimen'
+import LogoWithMicroscope from "@/assets/img/logo.svg";
+import type { Specimen } from "@/shared/Specimen";
 
-    const props = defineProps({
-        specimen: {
-            type: Object as PropType<UnwrapNestedRefs<Specimen>>,
-            required: true,
-        },
-    })
+const props = defineProps({
+  specimen: {
+    type: Object as PropType<UnwrapNestedRefs<Specimen>>,
+    required: true,
+  },
+});
 
-    const menuOpen = ref(false)
+const menuOpen = ref(false);
 
-    function toggleMenu() {
-        menuOpen.value = !menuOpen.value
-    }
+function toggleMenu() {
+  menuOpen.value = !menuOpen.value;
+}
 
-    function closeMenu() {
-        menuOpen.value = false
-    }
+function closeMenu() {
+  menuOpen.value = false;
+}
 
-    function seqWord() {
-        return props.specimen.sequenceName().split(/[\s:]/, 2)[0] || ''
-    }
-    function seqLink() {
-        return `/doc/src/sequences/${seqWord()}/`
-    }
-    function vizLink() {
-        return `/doc/src/visualizers/${props.specimen.visualizerKey}/`
-    }
+function seqWord() {
+  return props.specimen.sequenceName().split(/[\s:]/, 2)[0] || "";
+}
+function seqLink() {
+  return `/doc/src/sequences/${seqWord()}/`;
+}
+function vizLink() {
+  return `/doc/src/visualizers/${props.specimen.visualizerKey}/`;
+}
 </script>
 
 <style scoped lang="scss">
-    nav {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        padding: 8px 16px 8px 16px;
-        border-bottom: 1px solid var(--ns-color-black);
+nav {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 8px 16px 8px 16px;
+  border-bottom: 1px solid var(--ns-color-black);
+  position: relative;
 
-        #navbar-main {
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
+  #navbar-main {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 
-            #navbar-toggler {
-                background: none;
-                border: none;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
-        }
-
-        .close {
-            display: none;
-            font-size: 32px;
-            cursor: pointer;
-        }
-
-        .burger-menu {
-            color: var(--ns-color-black);
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            align-items: center;
-            &.open {
-                .material-icons-sharp {
-                    display: block;
-                }
-            }
-        }
-
-        #navbar-links {
-            width: 100%;
-            display: none;
-            flex-direction: column;
-            margin-top: 8px;
-            color: var(--ns-color-black);
-            &.open {
-                display: flex;
-                z-index: 1000;
-            }
-
-            @media (min-width: $mobile-breakpoint) {
-                display: flex;
-            }
-
-            .help-popper {
-                cursor: pointer;
-                font-family: var(--ns-font-display);
-                font-size: var(--ns-size-display);
-                position: relative;
-                padding-right: 0.5em;
-
-                a {
-                    font-family: var(--ns-font-display);
-                    text-decoration: none;
-                }
-                a:hover {
-                    text-decoration: underline;
-                }
-
-                #help-popup {
-                    visibility: hidden;
-                    display: flex;
-                    flex-direction: column;
-                    align-items: flex-end;
-                    align-content: flex-end;
-                    white-space: nowrap;
-                    position: absolute;
-                    right: 0;
-                    width: auto;
-                    z-index: 10000;
-                    background-color: var(--ns-color-white);
-                    opacity: 1;
-                    margin-top: 0.3ex;
-                    padding-bottom: 0.5ex;
-                    padding-top: 0.5ex;
-                    border: 1px solid var(--ns-color-black);
-
-                    .leftdented {
-                        padding-right: 0.5em;
-                    }
-
-                    .tweakup {
-                        position: relative;
-                        bottom: 6px;
-                    }
-
-                    .nav-link {
-                        color: var(--ns-color-black);
-                        padding-top: 0ex;
-                        padding-bottom: 0ex;
-                    }
-
-                    a {
-                        font-family: var(--ns-font-main);
-                        font-size: var(--ns-size-heading);
-                        text-decoration: none;
-                        padding-right: 0px;
-                    }
-
-                    a:hover {
-                        text-decoration: underline;
-                    }
-                }
-
-                &:hover #help-popup {
-                    visibility: visible;
-                    opacity: 1;
-                }
-            }
-
-            .nav-link {
-                font-family: var(--ns-font-display);
-                font-size: var(--ns-size-display);
-                color: var(--ns-color-black);
-                margin-top: 8px;
-                padding-left: 0.5em;
-                padding-right: 0.5em;
-                padding-top: 0.2ex;
-                padding-bottom: 0.2ex;
-                text-decoration: none;
-
-                &:focus,
-                &:hover {
-                    text-decoration: underline;
-                }
-
-                a:hover {
-                    text-decoration: underline;
-                }
-            }
-        }
+    #navbar-toggler {
+      background: none;
+      border: none;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
-    #logo {
-        img {
-            height: 32px;
-        }
+  }
+
+  .close {
+    display: none;
+    font-size: 32px;
+    cursor: pointer;
+  }
+
+  .burger-menu {
+    background-color: var(--ns-color-white);
+    color: var(--ns-color-black);
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    &.open {
+      .material-icons-sharp {
+        display: block;
+      }
     }
-    .specimen-bar {
-        display: none;
+  }
+
+  #navbar-links {
+    width: 100%;
+    display: none;
+    flex-direction: column;
+    color: var(--ns-color-black);
+    &.open {
+      display: flex;
+      z-index: 1000;
+    }
+
+    @media (max-width: $mobile-breakpoint) {
+      /* should not push content down */
+      background-color: var(--ns-color-white);
+      position: absolute;
+      top: 100%;
+      left: 0;
+      width: 100%;
+      padding: 0.2em 0.5em;
+    }
+
+    @media (min-width: $mobile-breakpoint) {
+      display: flex;
     }
 
     @media (min-width: $tablet-breakpoint) {
-        nav {
-            justify-content: space-between;
-            align-items: center;
-            flex-direction: row;
-            height: var(--ns-desktop-navbar-height);
-            #navbar-main {
-                #navbar-toggler {
-                    display: none;
-                }
-            }
-
-            #navbar-links {
-                align-items: center;
-                display: flex;
-                flex-direction: row;
-                margin-top: 0;
-                border-bottom: none;
-                width: unset;
-                gap: 24px;
-                .nav-link {
-                    margin-top: 0;
-                }
-            }
-        }
-        .specimen-bar {
-            display: flex;
-        }
+      margin-top: 8px;
     }
+
+    .help-popper {
+      cursor: pointer;
+      font-family: var(--ns-font-display);
+      font-size: var(--ns-size-display);
+      position: relative;
+      padding-right: 0.5em;
+
+      a {
+        font-family: var(--ns-font-display);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+
+      #help-popup {
+        visibility: hidden;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        align-content: flex-end;
+        white-space: nowrap;
+        position: absolute;
+        right: 0;
+        width: auto;
+        z-index: 10000;
+        background-color: var(--ns-color-white);
+        opacity: 1;
+        margin-top: 0.3ex;
+        padding-bottom: 0.5ex;
+        padding-top: 0.5ex;
+        border: 1px solid var(--ns-color-black);
+
+        .leftdented {
+          padding-right: 0.5em;
+        }
+
+        .tweakup {
+          position: relative;
+          bottom: 6px;
+        }
+
+        .nav-link {
+          color: var(--ns-color-black);
+          padding-top: 0ex;
+          padding-bottom: 0ex;
+        }
+
+        a {
+          font-family: var(--ns-font-main);
+          font-size: var(--ns-size-heading);
+          text-decoration: none;
+          padding-right: 0px;
+        }
+
+        a:hover {
+          text-decoration: underline;
+        }
+      }
+
+      &:hover #help-popup {
+        visibility: visible;
+        opacity: 1;
+      }
+    }
+
+    .nav-link {
+      font-family: var(--ns-font-display);
+      font-size: var(--ns-size-display);
+      color: var(--ns-color-black);
+      padding-right: 0.5em;
+      padding-bottom: 0.2ex;
+      text-decoration: none;
+
+      @media (min-width: $tablet-breakpoint) {
+        margin-top: 8px;
+        padding-top: 0.2ex;
+        padding-left: 0.5em;
+      }
+
+      &:focus,
+      &:hover {
+        text-decoration: underline;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+#logo {
+  img {
+    height: 32px;
+  }
+}
+.specimen-bar {
+  display: none;
+}
+
+@media (min-width: $tablet-breakpoint) {
+  nav {
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: row;
+    height: var(--ns-desktop-navbar-height);
+    #navbar-main {
+      #navbar-toggler {
+        display: none;
+      }
+    }
+
+    #navbar-links {
+      align-items: center;
+      display: flex;
+      flex-direction: row;
+      margin-top: 0;
+      border-bottom: none;
+      width: unset;
+      gap: 24px;
+      .nav-link {
+        margin-top: 0;
+      }
+    }
+  }
+  .specimen-bar {
+    display: flex;
+  }
+}
 </style>

--- a/src/views/minor/NavBar.vue
+++ b/src/views/minor/NavBar.vue
@@ -1,21 +1,20 @@
 <template>
     <header>
         <nav>
-            <div id="navbar-main">
-                <a id="logo" href="/doc/doc/about/">
-                    <img :src="LogoWithMicroscope" alt="A microscope icon.">
-                </a>
-                <button
-                    id="navbar-toggler"
-                    type="button"
-                    aria-controls="navbarSupportedContent"
-                    :aria-expanded="menuOpen"
-                    aria-label="Toggle navigation."
-                    @click="toggleMenu">
-                    <span class="material-icons-sharp">menu</span>
-                </button>
-            </div>
+            <a id="logo" href="/doc/doc/about/">
+                <img :src="LogoWithMicroscope" alt="A microscope icon.">
+            </a>
+
             <slot class="specimen-bar" />
+            <button
+                id="navbar-toggler"
+                type="button"
+                aria-controls="navbarSupportedContent"
+                :aria-expanded="menuOpen"
+                aria-label="Toggle navigation."
+                @click="toggleMenu">
+                <span class="material-icons-sharp">menu</span>
+            </button>
             <div class="burger-menu">
                 <div id="navbar-links" :class="{open: menuOpen}">
                     <RouterLink
@@ -90,24 +89,17 @@
 <style scoped lang="scss">
     nav {
         display: flex;
-        flex-direction: column;
-        justify-content: center;
+        justify-content: space-between;
         padding: 8px 16px 8px 16px;
         border-bottom: 1px solid var(--ns-color-black);
         position: relative;
 
-        #navbar-main {
+        #navbar-toggler {
+            background: none;
+            border: none;
             display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-
-            #navbar-toggler {
-                background: none;
-                border: none;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
+            justify-content: center;
+            align-items: center;
         }
 
         .close {
@@ -251,11 +243,15 @@
         }
     }
     #logo {
+        @media (max-width: $mobile-breakpoint) {
+            margin-right: auto;
+        }
+
         img {
             height: 24px;
 
             @media (min-width: $tablet-breakpoint) {
-                height: 32px;
+                height: 35px;
             }
         }
     }
@@ -269,10 +265,9 @@
             align-items: center;
             flex-direction: row;
             height: var(--ns-desktop-navbar-height);
-            #navbar-main {
-                #navbar-toggler {
-                    display: none;
-                }
+
+            #navbar-toggler {
+                display: none;
             }
 
             #navbar-links {


### PR DESCRIPTION
Improves the basic UI on phones.

https://github.com/user-attachments/assets/2fadde12-3824-47bd-a2e8-29adf8839347

- installed `@phosphor-icons/vue` to make the icons
- fixed the `isMobile()` function (the `--ns-breakpoint-tablet` CSS variable was not available due to incorrect SCSS interpolation)
- made the sequence/visualizer tabs pop open from the bottom

## Minor changes
- changed `visualiserTab` to `visualizerTab` for consistency
- `spec-name` should be a class instead of an ID since it appears twice (desktop and mobile)
- removed unnecessary `#navbar-main` div

## Not included

I have not:

- done any work on the gallery, sequence chooser, etc. (anything not shown in the above screengrab)
- tested on an actual phone, only in the browser's mobile emulation mode
